### PR TITLE
feat: add metadata.json persistence for distro server sessions

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -2649,6 +2649,8 @@
                   isNewSession: badgeNew,
                   parentSessionId,
                   spawnAgent,
+                  name: s.name || null,
+                  description: s.description || null,
                 });
                 sessionKeyById.set(sessionId, historyKey);
                 changed = true;


### PR DESCRIPTION
## Problem

The distro server (chat, Slack, voice) never wrote `metadata.json` for its sessions. This meant:
- Session names and descriptions were always blank in the chat sidebar
- The `hooks-session-naming` module couldn't write names because `prompt:complete` was never emitted by `loop-streaming`
- Readers in chat history and Slack discovery silently returned empty strings

## Changes

### Core persistence (`metadata_persistence.py` — new)
- `write_metadata()` — atomic merge-write that preserves fields from other writers (e.g. hooks-session-naming)
- `MetadataSaveHook` — fires on `orchestrator:complete`, writes initial metadata on first invocation, updates `turn_count`/`last_updated` on every turn
- Bridges `orchestrator:complete` → `prompt:complete` with `session_id` so `hooks-session-naming` fires for chat sessions (loop-streaming only emits `orchestrator:complete`, not `prompt:complete`)
- Deferred write: metadata is written on first `orchestrator:complete` (not at session creation) so we don't create the session directory before transcript.jsonl exists — avoids confusing the frontend revision poll

### Wiring (`session_backend.py`)
- `create_session()` passes initial metadata (session_id, created, bundle, working_dir, description) to the hook
- `_reconnect()` registers the metadata hook on resumed sessions

### Convention (`conventions.py`)
- Added `METADATA_FILENAME = "metadata.json"` alongside existing `TRANSCRIPT_FILENAME` and `SESSION_INFO_FILENAME`

### Readers
- `session_history.py` — reads `parent_id`, `agent_name`, `name`, `description` from metadata.json; enriches `scan_session_revisions()` with name/description for live title updates
- `slack/discovery.py` — uses `METADATA_FILENAME` constant instead of hardcoded string

### Frontend (`index.html`)
- Sidebar prefers `session.name` over `session.bundle` for the session label
- History fetch and revision poll pass `name`/`description` through to the session state

## Testing
- 928 tests pass (2 pre-existing Slack socket mode failures unrelated)
- Manual: start server, create chat session, send 2+ messages → name appears in sidebar