### PR TITLE
fix: resolve unresolved merge conflict markers in overlay.py

### DIFF
--- a/distro-server/src/amplifier_distro/overlay.py
+++ b/distro-server/src/amplifier_distro/overlay.py
@@ -90,11 +90,7 @@ def get_includes(data: dict[str, Any] | None = None) -> list[str]:
 
 
 def ensure_overlay(provider: Provider) -> Path:
-<<<<<<< HEAD
     """Create or update the overlay with the distro bundle + a provider.
-=======
-    """Create (or update) the overlay bundle with the distro bundle + a provider.
->>>>>>> 2a8acc42444e4bb95b41598b047af5369a23cc26
 
     If the overlay already exists, the provider include is added only if
     not already present.  The distro bundle include is always ensured.


### PR DESCRIPTION
## Problem

Commit 9beb8a0 ("Merge.") was pushed to main with unresolved conflict markers in `overlay.py`. The server crashes on startup:

```
SyntaxError: invalid decimal literal
  overlay.py, line 97: >>>>>>> 2a8acc42444e...
```

## Fix

One-line docstring wording difference — removed conflict markers, kept existing wording.