### PR TITLE
fix: remove hooks-session-naming from stale URIs migration list

### DIFF
--- a/distro-server/src/amplifier_distro/overlay.py
+++ b/distro-server/src/amplifier_distro/overlay.py
@@ -31,11 +31,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # URIs that should be silently removed (no replacement).
 _STALE_URIS: list[str] = [
-    # Session-naming hook was removed from the ecosystem.
-    (
-        "git+https://github.com/microsoft/amplifier-foundation@main"
-        "#subdirectory=modules/hooks-session-naming"
-    ),
+    # hooks-session-naming is now properly declared in the distro bundle at
+    # https://github.com/microsoft/amplifier-bundle-distro/blob/main/behaviors/start.yaml
+    # No longer needs migration stripping.
 ]
 
 # URIs that moved — old URI → current URI.  The overlay migration


### PR DESCRIPTION
## Summary

Removes `hooks-session-naming` from the `_STALE_URIS` migration list in `overlay.py`. This hook is not "removed from the ecosystem" as the old comment claimed - it's properly declared in [amplifier-bundle-distro/behaviors/start.yaml](https://github.com/microsoft/amplifier-bundle-distro/blob/main/behaviors/start.yaml) under the `hooks:` section.

## Background

The original comment said "Session-naming hook was removed from the ecosystem" but that's inaccurate. The hook exists and is properly configured - it was never in the user's overlay to begin with, so migration stripping isn't needed.

## Changes

- **Removed:** hooks-session-naming entry from `_STALE_URIS` list
- **Kept:** All migration infrastructure (`_URI_REPLACEMENTS`, `_migrate_includes()`, `migrate_overlay()`) for provider URI migrations

## Scope

This is a narrow fix - only removes the incorrect stale URI entry. All other migration functionality remains intact.