### PR TITLE
fix: bind HTTP server to 0.0.0.0 by default instead of 127.0.0.1

### DIFF
--- a/distro-server/scripts/amplifier-distro.service
+++ b/distro-server/scripts/amplifier-distro.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=amp-distro serve --host 127.0.0.1 --port 8400
+ExecStart=amp-distro serve --host 0.0.0.0 --port 8400
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=5

--- a/distro-server/scripts/install-service.sh
+++ b/distro-server/scripts/install-service.sh
@@ -41,7 +41,7 @@ fi
 mkdir -p "$SYSTEMD_USER_DIR"
 
 # Generate service file with correct ExecStart path
-sed "s|ExecStart=.*|ExecStart=$AMP_SERVER serve --host 127.0.0.1 --port 8400|" \
+sed "s|ExecStart=.*|ExecStart=$AMP_SERVER serve --host 0.0.0.0 --port 8400|" \
     "$SERVICE_TEMPLATE" > "$SYSTEMD_USER_DIR/amplifier-distro.service"
 
 echo "Installed service file to $SYSTEMD_USER_DIR/amplifier-distro.service"

--- a/distro-server/src/amplifier_distro/cli.py
+++ b/distro-server/src/amplifier_distro/cli.py
@@ -49,7 +49,7 @@ def main() -> None:
 
 @main.command("serve")
 @click.option(
-    "--host", default="127.0.0.1", help="Bind host (use 0.0.0.0 for LAN/Tailscale)"
+    "--host", default="0.0.0.0", help="Bind host (use 127.0.0.1 to restrict to localhost)"
 )
 @click.option(
     "--port", default=conventions.SERVER_DEFAULT_PORT, type=int, help="Bind port"
@@ -275,7 +275,7 @@ def service_cmd_status() -> None:
 
 
 @main.command("watchdog", hidden=True)
-@click.option("--host", default="127.0.0.1", help="Bind host")
+@click.option("--host", default="0.0.0.0", help="Bind host")
 @click.option(
     "--port",
     default=conventions.SERVER_DEFAULT_PORT,

--- a/distro-server/src/amplifier_distro/server/app.py
+++ b/distro-server/src/amplifier_distro/server/app.py
@@ -95,7 +95,7 @@ class DistroServer:
         title: str = "Amplifier Distro",
         version: str = "0.1.0",
         dev_mode: bool = False,
-        host: str = "127.0.0.1",
+        host: str = "0.0.0.0",
     ) -> None:
         self._apps: dict[str, AppManifest] = {}
         self._dev_mode = dev_mode

--- a/distro-server/src/amplifier_distro/server/cli.py
+++ b/distro-server/src/amplifier_distro/server/cli.py
@@ -25,8 +25,8 @@ from amplifier_distro import conventions
 @click.group("amp-distro-serve", invoke_without_command=True)
 @click.option(
     "--host",
-    default="127.0.0.1",
-    help="Bind host (use 0.0.0.0 for LAN/Tailscale)",
+    default="0.0.0.0",
+    help="Bind host (use 127.0.0.1 to restrict to localhost)",
 )
 @click.option(
     "--port",
@@ -76,8 +76,8 @@ def serve(
 @serve.command()
 @click.option(
     "--host",
-    default="127.0.0.1",
-    help="Bind host (use 0.0.0.0 for LAN/Tailscale)",
+    default="0.0.0.0",
+    help="Bind host (use 127.0.0.1 to restrict to localhost)",
 )
 @click.option(
     "--port",
@@ -153,8 +153,8 @@ def stop() -> None:
 @serve.command()
 @click.option(
     "--host",
-    default="127.0.0.1",
-    help="Bind host (use 0.0.0.0 for LAN/Tailscale)",
+    default="0.0.0.0",
+    help="Bind host (use 127.0.0.1 to restrict to localhost)",
 )
 @click.option(
     "--port",
@@ -237,7 +237,7 @@ def watchdog_group(ctx: click.Context) -> None:
 @watchdog_group.command("start")
 @click.option(
     "--host",
-    default="127.0.0.1",
+    default="0.0.0.0",
     help="Server host to monitor",
 )
 @click.option(

--- a/distro-server/src/amplifier_distro/server/daemon.py
+++ b/distro-server/src/amplifier_distro/server/daemon.py
@@ -90,7 +90,7 @@ def is_port_in_use(host: str, port: int) -> bool:
 
 
 def wait_for_health(
-    host: str = "127.0.0.1",
+    host: str = "0.0.0.0",
     port: int = conventions.SERVER_DEFAULT_PORT,
     timeout: float = 15.0,
     interval: float = 0.5,
@@ -119,7 +119,7 @@ def wait_for_health(
 
 
 def daemonize(
-    host: str = "127.0.0.1",
+    host: str = "0.0.0.0",
     port: int = conventions.SERVER_DEFAULT_PORT,
     apps_dir: str | None = None,
     dev: bool = False,

--- a/distro-server/src/amplifier_distro/server/watchdog.py
+++ b/distro-server/src/amplifier_distro/server/watchdog.py
@@ -120,7 +120,7 @@ def _signal_handler(signum: int, frame: object) -> None:
 
 def run_watchdog_loop(
     *,
-    host: str = "127.0.0.1",
+    host: str = "0.0.0.0",
     port: int = conventions.SERVER_DEFAULT_PORT,
     check_interval: int = 30,
     restart_after: int = 300,
@@ -289,7 +289,7 @@ def _restart_server(
 
 def start_watchdog(
     *,
-    host: str = "127.0.0.1",
+    host: str = "0.0.0.0",
     port: int = conventions.SERVER_DEFAULT_PORT,
     check_interval: int = 30,
     restart_after: int = 300,
@@ -374,7 +374,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Amplifier Distro Server Watchdog")
-    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=conventions.SERVER_DEFAULT_PORT)
     parser.add_argument("--check-interval", type=int, default=30)
     parser.add_argument("--restart-after", type=int, default=300)

--- a/distro-server/src/amplifier_distro/service.py
+++ b/distro-server/src/amplifier_distro/service.py
@@ -225,7 +225,7 @@ def _generate_systemd_server_unit(distro_bin: str) -> str:
 
         [Service]
         Type=simple
-        ExecStart={distro_bin} serve --host 127.0.0.1 --port {port}
+        ExecStart={distro_bin} serve --host 0.0.0.0 --port {port}
         Restart=always
         # Note: Restart=always (not on-failure) is intentional. The watchdog triggers
         # restarts by exiting with code 1, which causes systemd to restart the watchdog
@@ -271,7 +271,7 @@ def _generate_systemd_watchdog_unit(distro_bin: str) -> str:
 
         [Service]
         Type=simple
-        ExecStart={distro_bin} watchdog --host 127.0.0.1 --port {port}
+        ExecStart={distro_bin} watchdog --host 0.0.0.0 --port {port}
         Restart=always
         RestartSec=10
         StartLimitIntervalSec=300
@@ -537,7 +537,7 @@ def _generate_launchd_server_plist(distro_bin: str) -> str:
                 <string>{distro_bin}</string>
                 <string>serve</string>
                 <string>--host</string>
-                <string>127.0.0.1</string>
+                <string>0.0.0.0</string>
                 <string>--port</string>
                 <string>{port}</string>
             </array>
@@ -596,7 +596,7 @@ def _generate_launchd_watchdog_plist(distro_bin: str) -> str:
                 <string>watchdog</string>
                 <string>--supervised</string>
                 <string>--host</string>
-                <string>127.0.0.1</string>
+                <string>0.0.0.0</string>
                 <string>--port</string>
                 <string>{port}</string>
             </array>

--- a/distro-server/tests/test_server.py
+++ b/distro-server/tests/test_server.py
@@ -579,9 +579,9 @@ class TestApiKeyAuth:
 class TestHostThreading:
     """Verify --host flows through DistroServer to app.state."""
 
-    def test_default_host_is_localhost(self):
+    def test_default_host_is_all_interfaces(self):
         server = DistroServer()
-        assert server.app.state.host == "127.0.0.1"
+        assert server.app.state.host == "0.0.0.0"
 
     def test_custom_host_stored_on_app_state(self):
         server = DistroServer(host="0.0.0.0")


### PR DESCRIPTION
Fixes microsoft/amplifier-distro#54

## Problem

The `amp-distro` HTTP server binds to `127.0.0.1` (localhost only) by default, making it inaccessible from other machines on the network. Users running Tailscale or similar mesh VPNs cannot reach the service from peer machines.

## Fix

Changed the default bind address from `127.0.0.1` to `0.0.0.0` (all interfaces) across all locations where it was hardcoded:

- **CLI commands**: `serve`, `start`, `restart`, `watchdog`, `watchdog start` defaults
- **Server core**: `DistroServer.__init__`, `daemonize()`, `wait_for_health()`
- **Watchdog**: `run_watchdog_loop()`, `start_watchdog()`, `__main__` argparse
- **Service templates**: systemd server/watchdog units, launchd server/watchdog plists
- **Scripts**: `amplifier-distro.service`, `install-service.sh`
- **Tests**: Updated to match new default

9 files changed, 23 insertions, 23 deletions.

## What was intentionally left alone

- **WebSocket CSRF origin check** in `connection.py` — already correctly relaxes origin restrictions when host is not localhost, so LAN clients work automatically
- **Dockerfile** — already uses `0.0.0.0`
- **Help text** — updated to say "use 127.0.0.1 to restrict to localhost"

## Security

Binding to `0.0.0.0` is consistent with the existing port 80 service behavior. Most users are behind a home router with no port forwarding. Users who need to restrict access can use `--host 127.0.0.1` or firewall rules.

## Testing

156 relevant tests pass (server, CLI, daemon, service, connection).