### PR TITLE
fix: unregister hooks on ChatConnection disconnect

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/connection.py
+++ b/distro-server/src/amplifier_distro/server/apps/chat/connection.py
@@ -14,6 +14,7 @@ import contextlib
 import hmac
 import logging
 import re
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from starlette.websockets import WebSocketDisconnect
@@ -70,6 +71,10 @@ class ChatConnection:
         # keeps strong refs to fire-and-forget tasks so GC can't collect them
         self._tasks: set[asyncio.Task] = set()
         self._active_execution: asyncio.Task | None = None
+        # Hook unregister callable -- mirrors VoiceConnection._hook_unregister.
+        # Called on disconnect to remove stale hooks from the coordinator and
+        # clear _wired_sessions so the next reconnect re-registers fresh hooks.
+        self._hook_unregister: Callable[[], None] | None = None
         # tracks which local block indices received at least one delta
         self._seen_deltas: set[int] = set()
 
@@ -102,12 +107,41 @@ class ChatConnection:
             fanout_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await fanout_task
+            # Unregister hooks so stale closures don't push to the dead queue.
+            # This clears _wired_sessions so the next reconnect re-registers
+            # fresh hooks against the new queue (mirrors VoiceConnection._cleanup_hook).
+            self._cleanup_hook()
             # Keep session handles alive on disconnect so they can be resumed
             # after refresh/new tab via resume_session_id.
             if self._session_id:
                 with contextlib.suppress(Exception):
                     await self._backend.cancel_session(self._session_id, "graceful")
             await self.event_queue.put(_STOP)
+
+    def _cleanup_hook(self) -> None:
+        """Unregister the hook if one is registered. Always safe to call.
+
+        Mirrors VoiceConnection._cleanup_hook() -- removes stale hooks from
+        the coordinator and clears _wired_sessions so the next reconnect
+        re-registers fresh hooks against the new event queue.
+        """
+        if self._hook_unregister is not None:
+            try:
+                self._hook_unregister()
+            except Exception:  # noqa: BLE001
+                logger.warning("Error unregistering chat event hooks", exc_info=True)
+            finally:
+                self._hook_unregister = None
+
+    def _fetch_hook_unregister(self, session_id: str) -> None:
+        """Fetch and store the hook unregister callable for a session.
+
+        Called after create_session/resume_session to capture the callable
+        that _cleanup_hook() will invoke on disconnect.
+        """
+        get_unregister = getattr(self._backend, "get_hook_unregister", None)
+        if get_unregister is not None:
+            self._hook_unregister = get_unregister(session_id)
 
     async def _auth_handshake(self) -> None:
         """Validate auth token if api_key is configured.
@@ -281,6 +315,11 @@ class ChatConnection:
 
             self._session_id = session_id
             self._translator.reset()
+
+            # Fetch and store the hook unregister callable so _cleanup_hook()
+            # can remove registered hooks on disconnect (mirrors VoiceConnection).
+            self._fetch_hook_unregister(session_id)
+
             await self._ws.send_json(
                 {
                     "type": "session_created",
@@ -349,6 +388,7 @@ class ChatConnection:
             case "bundle" if args:
                 new_bundle = args[0]
                 if self._session_id:
+                    self._cleanup_hook()
                     await self._backend.cancel_session(self._session_id, "graceful")
                     with contextlib.suppress(Exception):
                         await self._backend.end_session(self._session_id)
@@ -358,10 +398,12 @@ class ChatConnection:
                 )
                 self._session_id = info.session_id
                 self._translator.reset()
+                self._fetch_hook_unregister(info.session_id)
                 return {"bundle": new_bundle, "session_id": info.session_id}
             case "cwd" if args:
                 new_cwd = args[0]
                 if self._session_id:
+                    self._cleanup_hook()
                     await self._backend.cancel_session(self._session_id, "graceful")
                     with contextlib.suppress(Exception):
                         await self._backend.end_session(self._session_id)
@@ -371,6 +413,7 @@ class ChatConnection:
                 )
                 self._session_id = info.session_id
                 self._translator.reset()
+                self._fetch_hook_unregister(info.session_id)
                 return {"cwd": new_cwd, "session_id": info.session_id}
             case "config":
                 return self._build_config_summary()

--- a/distro-server/tests/test_chat_connection.py
+++ b/distro-server/tests/test_chat_connection.py
@@ -330,6 +330,243 @@ class TestInputValidation:
         assert "Invalid working directory" in errors[0]["error"]
 
 
+class TestHookCleanup:
+    """Tests for hook unregistration on disconnect (BUG-1, issue #59)."""
+
+    @pytest.mark.asyncio
+    async def test_hook_unregister_called_on_disconnect(self):
+        """ChatConnection must call hook_unregister on disconnect."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        unregister_called = False
+
+        def mock_unregister():
+            nonlocal unregister_called
+            unregister_called = True
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+            ]
+        )
+        backend = make_backend()
+        backend.get_hook_unregister = MagicMock(return_value=mock_unregister)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        assert unregister_called, "hook_unregister must be called on disconnect"
+
+    @pytest.mark.asyncio
+    async def test_hook_unregister_fetched_on_create_session(self):
+        """ChatConnection must fetch hook_unregister after creating a session."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+            ]
+        )
+        backend = make_backend("sess-new")
+        backend.get_hook_unregister = MagicMock(return_value=lambda: None)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        backend.get_hook_unregister.assert_called_once_with("sess-new")
+
+    @pytest.mark.asyncio
+    async def test_hook_unregister_fetched_on_resume_session(self):
+        """ChatConnection must fetch hook_unregister after resuming a session."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        ws = make_ws(
+            [
+                {
+                    "type": "create_session",
+                    "cwd": "/tmp",
+                    "resume_session_id": "sess-resumed",
+                },
+            ]
+        )
+        backend = make_backend("sess-resumed")
+        backend.get_hook_unregister = MagicMock(return_value=lambda: None)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        backend.get_hook_unregister.assert_called_once_with("sess-resumed")
+
+    @pytest.mark.asyncio
+    async def test_hook_unregister_cleared_after_call(self):
+        """After calling hook_unregister, the reference should be cleared to None."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+            ]
+        )
+        backend = make_backend()
+        backend.get_hook_unregister = MagicMock(return_value=lambda: None)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        assert conn._hook_unregister is None, (
+            "hook_unregister reference must be cleared after call"
+        )
+
+    @pytest.mark.asyncio
+    async def test_hook_unregister_error_does_not_crash(self):
+        """If hook_unregister raises, disconnect should still complete cleanly."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        def bad_unregister():
+            raise RuntimeError("unregister failed")
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+            ]
+        )
+        backend = make_backend()
+        backend.get_hook_unregister = MagicMock(return_value=bad_unregister)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        # Should not raise despite the bad unregister
+        await conn.run()
+
+        # Reference should still be cleared even on error
+        assert conn._hook_unregister is None
+
+    @pytest.mark.asyncio
+    async def test_no_hook_unregister_when_no_session(self):
+        """When no session is created, no hook_unregister should be called."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        ws = make_ws([])  # disconnect immediately, no create_session
+        backend = make_backend()
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        assert conn._hook_unregister is None
+
+    @pytest.mark.asyncio
+    async def test_bundle_command_cleans_old_hooks_and_wires_new(self):
+        """Switching bundle via /command must cleanup old hooks and wire new ones."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        calls = []
+
+        def old_unregister():
+            calls.append("old_unregister")
+
+        def new_unregister():
+            calls.append("new_unregister")
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+                {"type": "command", "name": "bundle", "args": ["new-bundle"]},
+            ]
+        )
+        backend = make_backend("sess-old")
+        # First call returns old_unregister, second returns new_unregister
+        backend.get_hook_unregister = MagicMock(
+            side_effect=[old_unregister, new_unregister]
+        )
+        backend.end_session = AsyncMock()
+        # create_session returns different session IDs
+        new_info = MagicMock()
+        new_info.session_id = "sess-new"
+        new_info.working_dir = "/tmp"
+        backend.create_session = AsyncMock(side_effect=[backend.create_session.return_value, new_info])
+        # Fix: re-set the first return to the original
+        old_info = MagicMock()
+        old_info.session_id = "sess-old"
+        old_info.working_dir = "/tmp"
+        backend.create_session = AsyncMock(side_effect=[old_info, new_info])
+        backend.get_session_info = AsyncMock(return_value=old_info)
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        # Old hooks should be cleaned up before new session created
+        assert "old_unregister" in calls, "Old session hooks must be unregistered"
+        # New hooks should be fetched for the replacement session
+        assert backend.get_hook_unregister.call_count == 2
+        # On final disconnect, new hooks should be cleaned up
+        assert "new_unregister" in calls, "New session hooks must be unregistered on disconnect"
+
+    @pytest.mark.asyncio
+    async def test_cwd_command_cleans_old_hooks_and_wires_new(self):
+        """Switching cwd via /command must cleanup old hooks and wire new ones."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        unregister_calls = []
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+                {"type": "command", "name": "cwd", "args": ["/new/path"]},
+            ]
+        )
+        old_info = MagicMock()
+        old_info.session_id = "sess-old"
+        old_info.working_dir = "/tmp"
+        new_info = MagicMock()
+        new_info.session_id = "sess-new-cwd"
+        new_info.working_dir = "/new/path"
+
+        backend = make_backend()
+        backend.create_session = AsyncMock(side_effect=[old_info, new_info])
+        backend.get_session_info = AsyncMock(return_value=old_info)
+        backend.end_session = AsyncMock()
+        backend.get_hook_unregister = MagicMock(
+            side_effect=[
+                lambda: unregister_calls.append("old"),
+                lambda: unregister_calls.append("new"),
+            ]
+        )
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()
+
+        assert "old" in unregister_calls, "Old session hooks must be unregistered"
+        assert "new" in unregister_calls, "New session hooks must be unregistered on disconnect"
+
+    @pytest.mark.asyncio
+    async def test_works_without_get_hook_unregister_method(self):
+        """If backend lacks get_hook_unregister, disconnect should still work."""
+        from amplifier_distro.server.apps.chat.connection import ChatConnection
+
+        ws = make_ws(
+            [
+                {"type": "create_session", "cwd": "/tmp"},
+            ]
+        )
+        backend = make_backend()
+        # Explicitly remove the method (simulates older backend)
+        if hasattr(backend, "get_hook_unregister"):
+            del backend.get_hook_unregister
+        config = make_config()
+
+        conn = ChatConnection(ws, backend, config)
+        await conn.run()  # Should not raise
+
+        assert conn._hook_unregister is None
+
+
 class TestEventQueueBounded:
     def test_event_queue_has_maxsize(self):
         """event_queue must be bounded to prevent unbounded memory growth."""


### PR DESCRIPTION
## Summary
Fixes hook registration leaks on ChatConnection disconnect that prevented proper cleanup and caused frozen reconnects.

- Mirrored VoiceConnection's established `_cleanup_hook()` pattern to ChatConnection
- Applied same pattern to /bundle and /cwd command session management
- Added comprehensive test coverage for hook cleanup scenarios

## Test plan
✓ All 31 tests pass, including 9 new tests covering:
  - Hook cleanup called on disconnect
  - Hook registration on create and resume
  - Hook deregistration error handling
  - Bundle and cwd command cleanup patterns
  - Missing backend method scenarios