### PR TITLE
fix: add QueueFull guard to QueueDisplaySystem.show_message()

### DIFF
--- a/distro-server/src/amplifier_distro/server/protocol_adapters.py
+++ b/distro-server/src/amplifier_distro/server/protocol_adapters.py
@@ -104,12 +104,15 @@ class QueueDisplaySystem:
         level: Literal["info", "warning", "error"] = "info",
         source: str = "hook",
     ) -> None:
-        self._queue.put_nowait(
-            (
-                "display_message",
-                {"message": message, "level": level, "source": source},
+        try:
+            self._queue.put_nowait(
+                (
+                    "display_message",
+                    {"message": message, "level": level, "source": source},
+                )
             )
-        )
+        except asyncio.QueueFull:
+            logger.warning("Event queue full, dropping display_message")
 
     def push_nesting(self) -> QueueDisplaySystem:
         return QueueDisplaySystem(self._queue, self._nesting_depth + 1)

--- a/distro-server/tests/test_protocol_adapters.py
+++ b/distro-server/tests/test_protocol_adapters.py
@@ -182,3 +182,17 @@ class TestQueueDisplaySystem:
         d = QueueDisplaySystem(q)
         d2 = d.pop_nesting()
         assert d2.nesting_depth == 0
+
+    async def test_show_message_does_not_raise_on_full_queue(self):
+        """show_message must not raise QueueFull when queue is full (issue #67)."""
+        from amplifier_distro.server.protocol_adapters import QueueDisplaySystem
+
+        q: asyncio.Queue = asyncio.Queue(maxsize=1)
+        display = QueueDisplaySystem(q)
+        # Fill the queue
+        await display.show_message("first")
+        assert q.qsize() == 1
+        # Second message should be silently dropped, not raise
+        await display.show_message("second")  # must not raise
+        # Queue should still have exactly 1 item
+        assert q.qsize() == 1


### PR DESCRIPTION
## Summary
- Added try/except asyncio.QueueFull guard to QueueDisplaySystem.show_message() to prevent a full queue from raising into the calling hook and potentially crashing tool execution
- Added 1 test
- All 14 protocol_adapters tests pass

## Test plan
- All 14 protocol_adapters tests pass
- New test added for QueueFull guard behavior

Fixes #67

🤖 Generated with Amplifier