### PR TITLE
fix: guard rename and overflow menu for new sessions

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -1940,7 +1940,7 @@
     `;
   }
 
-  function SessionOverflowMenu({ isPinned, canPin, onPin, onRename, onClose }) {
+  function SessionOverflowMenu({ isPinned, canPin, onPin, canRename, onRename, onClose }) {
     const menuRef = useRef(null);
     useEffect(() => {
       function handleClickOutside(e) {
@@ -1962,10 +1962,12 @@
             ${isPinned ? 'Unpin' : 'Pin to top'}
           </button>
         `}
-        <button class="session-overflow-item" role="menuitem"
-          onClick=${(e) => { e.stopPropagation(); onRename(); onClose(); }}>
-          Rename
-        </button>
+        ${canRename && html`
+          <button class="session-overflow-item" role="menuitem"
+            onClick=${(e) => { e.stopPropagation(); onRename(); onClose(); }}>
+            Rename
+          </button>
+        `}
       </div>
     `;
   }
@@ -2115,21 +2117,28 @@
               </span>`
           }
         </div>
-        <div class=${'session-card-actions' + (menuOpen ? ' menu-open' : '')}>
-          <button class="session-card-action-btn" title="More actions" aria-label="Session actions"
-            aria-haspopup="menu"
-            onClick=${(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
-          ><${Icon} name="more-vertical" /></button>
-          ${menuOpen && html`
-            <${SessionOverflowMenu}
-              isPinned=${isPinned}
-              canPin=${!!session.sessionId && (session.turnCount || session.messageCount || 0) > 0}
-              onPin=${() => onTogglePin(session.sessionId, isPinned)}
-              onRename=${(e) => startEditing(e)}
-              onClose=${() => setMenuOpen(false)}
-            />
-          `}
-        </div>
+        ${(() => {
+          const hasSession = !!session.sessionId && (session.turnCount || session.messageCount || 0) > 0;
+          if (!hasSession) return null;
+          return html`
+            <div class=${'session-card-actions' + (menuOpen ? ' menu-open' : '')}>
+              <button class="session-card-action-btn" title="More actions" aria-label="Session actions"
+                aria-haspopup="menu"
+                onClick=${(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
+              ><${Icon} name="more-vertical" /></button>
+              ${menuOpen && html`
+                <${SessionOverflowMenu}
+                  isPinned=${isPinned}
+                  canPin=${hasSession}
+                  onPin=${() => onTogglePin(session.sessionId, isPinned)}
+                  canRename=${hasSession}
+                  onRename=${(e) => startEditing(e)}
+                  onClose=${() => setMenuOpen(false)}
+                />
+              `}
+            </div>
+          `;
+        })()}
         <div class="session-card-cwd session-card-cwd-row" title=${session.cwd || '~'}>
           <${Icon} name="folder" className="sm" />
           <span class="session-card-line-text">${session.cwd || '~'}</span>


### PR DESCRIPTION
## Summary
- Fixed a bug where the overflow menu (`...` icon) and Rename option were shown on new sessions with no conversation
- These new sessions have no disk directory yet, so renaming silently fails or doesn't persist
- Replaced PR #83 which had merge conflicts from a rebase; this is a clean, minimal implementation on latest `main`

## Changes
- Added `canRename` guard to `SessionOverflowMenu` (matching the existing `canPin` pattern)
- Wrapped the entire actions div in a `hasSession` check so the overflow button is hidden when there are no available actions
- Single `hasSession` variable computes `!!session.sessionId && turnCount > 0` once, used for both `canPin` and `canRename`

## Test plan
- [ ] Load chat app, create a new session with no messages
- [ ] Verify the overflow menu (`...` icon) is NOT visible on the new session card
- [ ] Send a message and verify the overflow menu becomes visible after the first turn completes
- [ ] Verify Pin and Rename options work as expected in the overflow menu