### PR TITLE
Fix button overlap in session rename UI

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -1107,6 +1107,44 @@
     @media (hover: none), (pointer: coarse) {
       .session-card-actions { opacity: 1; }
     }
+
+    /* Hide three-dot menu during editing to prevent overlap */
+    .session-name-editing .session-card-actions {
+      display: none;
+    }
+
+    /* Move edit actions to top-right corner (swap with three-dot menu) */
+    .session-name-editing .session-edit-actions {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+      z-index: 1;
+    }
+
+    /* Style edit buttons to match three-dot menu visual weight */
+    .session-name-editing .session-edit-actions button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+      padding: 0;
+      border-radius: 5px;
+      background: var(--action-btn-bg);
+      color: var(--action-btn-color);
+      font-size: 12px;
+      border: none;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+
+    .session-name-editing .session-edit-actions button:hover {
+      background: var(--action-btn-bg-hover);
+      color: var(--action-btn-color-hover);
+    }
     .session-card-action-btn {
       position: relative;
       display: inline-flex;


### PR DESCRIPTION
## Problem

When renaming a session in the chat app, the discard button overlaps with the three-dot menu icon, creating a poor user experience and making both controls difficult to use.

## Solution

This PR implements a 'swap pattern' where:
- The three-dot menu is hidden during edit mode
- Save (✓) and discard (✕) buttons move to the top-right corner where the three-dot menu was
- Clean state transition with zero layout shift
- CSS-only fix, no component restructuring needed

## Benefits

- **Full input width** - The rename input gets the entire name row
- **Spatial consistency** - Action buttons always appear in the same corner
- **Zero layout shift** - Card dimensions stay consistent during the transition
- **Low risk** - About 40 lines of CSS, no HTML or component changes
- **Better UX** - Clear, unobstructed controls during rename operation

## Changes

- Added CSS rules to `distro-server/src/amplifier_distro/server/apps/chat/static/index.html`
  - Hide three-dot menu when in edit mode
  - Reposition save/discard buttons to top-right corner
  - Style buttons to match the visual weight of the three-dot menu

## Testing

Manual testing recommended:
1. Open the chat app
2. Click the three-dot menu on any session
3. Select 'Rename'
4. Verify save/discard buttons appear in the top-right corner without overlap
5. Verify the input field has full width
6. Test hover states on save/discard buttons