### PR TITLE
fix: show session overflow menu as soon as session is created

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -2218,7 +2218,7 @@
           }
         </div>
         ${(() => {
-          const hasSession = !!session.sessionId && (session.turnCount || session.messageCount || 0) > 0;
+          const hasSession = !!session.sessionId;
           if (!hasSession) return null;
           return html`
             <div class=${'session-card-actions' + (menuOpen ? ' menu-open' : '')}>


### PR DESCRIPTION
## Problem

The overflow menu button (with Pin and Rename actions) was previously gated behind both having a session ID AND having at least one completed turn. This meant users had to wait for the entire first LLM response to complete before they could access these actions.

## Solution

Since both Pin and Rename only require the session ID (they call API endpoints with just the ID), and the session ID arrives immediately on the `session_created` WebSocket event, we can show the menu much sooner.

## Changes

- **distro-server/.../index.html**: Remove turn/message count check from `hasSession` condition
- **.amplifier/AGENTS.md**: Update pin gating rule documentation to reflect that only `sessionId` is required

## Impact

Users can now access Pin and Rename actions immediately after a session is created, rather than waiting for the first LLM turn to complete. This improves UX for long-running first responses.