### PR TITLE
fix(web-chat): add block scopes to case blocks with lexical declarations

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -2889,7 +2889,7 @@
           });
           break;
 
-        case 'content_start':
+        case 'content_start': {
           // Remove client-side placeholder if present
           const placeholderId = placeholderIdRef.current;
           if (placeholderId) {
@@ -2915,6 +2915,7 @@
             }]);
           }
           break;
+        }
 
         case 'content_delta': {
           const delta = typeof msg.delta === 'string' ? msg.delta : '';
@@ -3132,7 +3133,7 @@
           setExecuting(false);
           break;
 
-        case 'execution_error':
+        case 'execution_error': {
           // Remove client-side placeholder if error occurs immediately
           const placeholderId = placeholderIdRef.current;
           if (placeholderId) {
@@ -3156,6 +3157,7 @@
             streaming: false, order: orderCounterRef.current++,
           }]);
           break;
+        }
 
         case 'command_result': {
           const fmt = formatCommandResult(msg.command, msg.result);


### PR DESCRIPTION
## Summary
Fixes two block-scoping issues in the WebSocket message handler that were inadvertently omitted from the web chat responsiveness PR.

This PR adds block scope braces around two `case` blocks that declare `const` variables:
- `case 'content_start':` block (line ~2888)
- `case 'execution_error':` block (line ~3131)

Without proper block scoping, JavaScript lexical scoping rules would cause variable declaration issues.

## Changes
- Added opening brace `{` after `case 'content_start':`
- Added closing brace `}` before the break statement
- Added opening brace `{` after `case 'execution_error':`
- Added closing brace `}` before the break statement

## Test plan
- Code review of the JavaScript scoping changes
- Verify no regression in existing functionality