### PR TITLE
fix: remove dead GET /apps/settings/bridges endpoint

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/settings/__init__.py
+++ b/distro-server/src/amplifier_distro/server/apps/settings/__init__.py
@@ -10,7 +10,6 @@ Routes:
     POST /features  - Toggle a feature on/off
     POST /tier      - Set feature tier level
     POST /provider  - Add/update provider (key entry or use existing key)
-    GET  /bridges   - Bridge configuration status
 """
 
 from __future__ import annotations
@@ -401,12 +400,6 @@ async def change_provider(req: ProviderRequest) -> dict[str, Any]:
     except Exception as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     return result
-
-
-@router.get("/bridges")
-async def get_bridges() -> dict[str, Any]:
-    """Status of all communication bridges (Slack, Voice)."""
-    return {"bridges": detect_bridges()}
 
 
 # --- Distro Settings CRUD ---


### PR DESCRIPTION
Closes microsoft/amplifier-distro#107

## Summary

The `GET /apps/settings/bridges` endpoint was implemented but never called by any frontend or backend code. This PR removes it.

## Investigation

An exhaustive search confirmed the endpoint is dead:
- **No frontend calls** — `settings.html` never fetches `/bridges`
- **No backend calls** — no Python code invokes it
- **No tests** — zero test coverage for the endpoint
- Bridge status is already served by two live endpoints:
  - `GET /apps/settings/status` — includes `bridges` in the full status blob via `_build_status()` → `detect_bridges()`
  - `GET /apps/install-wizard/detect` — includes `bridges` in environment detection via its own call to `detect_bridges()`
- The frontend settings UI uses `GET /api/integrations` (a separate, independently implemented endpoint in `app.py`) for integration status

## Changes

- Removed the `@router.get("/bridges")` route handler (4 lines)
- Updated the module docstring to remove `/bridges` from the documented routes table
- **Kept** the `detect_bridges()` helper — it's still used by the live `/status` and `/detect` endpoints