### PR TITLE
fix: resolve memory stats dashboard always showing 0

### DIFF
--- a/distro-server/src/amplifier_distro/server/app.py
+++ b/distro-server/src/amplifier_distro/server/app.py
@@ -585,6 +585,22 @@ class DistroServer:
                     content={"error": str(e), "type": type(e).__name__},
                 )
 
+        @self._core_router.get("/memory/stats")
+        async def memory_stats() -> JSONResponse:
+            """Return aggregate memory statistics."""
+            from amplifier_distro.server.memory import get_memory_service
+
+            try:
+                service = get_memory_service()
+                result = service.stats()
+                return JSONResponse(content=result)
+            except (RuntimeError, OSError, ValueError, KeyError) as e:
+                logger.warning("Memory stats failed: %s", e, exc_info=True)
+                return JSONResponse(
+                    status_code=500,
+                    content={"error": str(e), "type": type(e).__name__},
+                )
+
         @self._core_router.get("/memory/recall")
         async def memory_recall(q: str = "") -> JSONResponse:
             """Search memories by content, tags, and category."""

--- a/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
+++ b/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
@@ -877,7 +877,7 @@ async function loadAll() {
     fetch('/apps/install-wizard/detect').then(r => r.ok ? r.json() : { error: 'HTTP ' + r.status }).catch(() => ({ error: true })),
     api('GET', '/distro-settings'),
     coreApi('GET', '/integrations'),
-    coreApi('GET', '/memory/recall?q=*').catch(() => ({ error: true })),
+    coreApi('GET', '/memory/stats').catch(() => ({ error: true })),
     coreApi('GET', '/memory/work-status'),
     coreApi('GET', '/status'),
     api('GET', '/providers'),
@@ -1322,14 +1322,14 @@ function renderMemoryStats() {
 
   let lastUpdate = '--';
   if (state.workStatus && state.workStatus.items && state.workStatus.items.length > 0) {
-    const last = state.workStatus.items[state.workStatus.items.length - 1];
-    if (last.updated) {
+    const maxTs = Math.max(...state.workStatus.items
+      .filter(i => i.updated)
+      .map(i => new Date(i.updated).getTime()));
+    if (isFinite(maxTs)) {
       try {
-        const d = new Date(last.updated);
+        const d = new Date(maxTs);
         lastUpdate = d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
-      } catch (e) {
-        lastUpdate = last.updated;
-      }
+      } catch (e) { lastUpdate = '--'; }
     }
   }
 

--- a/distro-server/src/amplifier_distro/server/memory.py
+++ b/distro-server/src/amplifier_distro/server/memory.py
@@ -332,6 +332,21 @@ class MemoryService:
         logger.info("Stored memory %s (category: %s)", mem_id, category)
         return entry.model_dump()
 
+    def stats(self) -> dict[str, Any]:
+        """Return aggregate memory statistics without loading full content.
+
+        Returns:
+            Dict with memory_count and per-category breakdown.
+        """
+        store = self._load_store()
+        by_category: dict[str, int] = {}
+        for m in store.memories:
+            by_category[m.category] = by_category.get(m.category, 0) + 1
+        return {
+            "count": len(store.memories),
+            "by_category": by_category,
+        }
+
     def recall(self, query: str) -> list[dict[str, Any]]:
         """Search memories by content, tags, and category.
 


### PR DESCRIPTION
Closes microsoft/amplifier-distro#112

## Problem

The dashboard Memory stats always showed `0` because the UI called `GET /api/memory/recall?q=*`, but `recall()` performs literal substring matching — the `*` character never matches any real memory content. A secondary bug: the "Last Update" timestamp displayed the last-appended work item rather than the most recently updated one.

## Fix

**`memory.py`** — Added a `stats()` method to `MemoryService` that returns `{count, by_category}` directly from the store without serializing full memory content.

**`app.py`** — Added `GET /api/memory/stats` route in `_setup_memory_routes()` that calls `service.stats()`. This decouples counting from searching — no need to send all memory entries over the wire just to get a count.

**`settings.html`** — Two changes:
- `loadAll()` now calls `/memory/stats` instead of `/memory/recall?q=*`
- `renderMemoryStats()` computes "Last Update" using `Math.max()` over all work item `updated` timestamps instead of blindly taking the last array element

## Why not just fix `recall()`?

Special-casing `q=*` in `recall()` would work but is a hack — it couples a general-purpose search method to a UI concern, and still sends the full memory payload over the wire just for a count. A dedicated stats endpoint is the clean fix.