### PR TITLE
fix(web-chat): sync CWD state when editing draft session working directory

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/connection.py
+++ b/distro-server/src/amplifier_distro/server/apps/chat/connection.py
@@ -444,6 +444,8 @@ class ChatConnection:
                 return {"bundle": new_bundle, "session_id": info.session_id}
             case "cwd" if args:
                 new_cwd = args[0]
+                if "\x00" in new_cwd:
+                    return {"error": "Invalid working directory"}
                 if self._session_id:
                     self._cleanup_hook()
                     await self._backend.cancel_session(self._session_id, "graceful")
@@ -456,7 +458,7 @@ class ChatConnection:
                 self._session_id = info.session_id
                 self._translator.reset()
                 self._fetch_hook_unregister(info.session_id)
-                return {"cwd": new_cwd, "session_id": info.session_id}
+                return {"cwd": str(info.working_dir), "session_id": info.session_id}
             case "config":
                 return self._build_config_summary()
             case "tools":

--- a/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/chat/static/index.html
@@ -2740,6 +2740,7 @@
               ...s,
               sessionId: msg.session_id,
               cwd: msg.cwd || '~',
+              serverCwd: msg.cwd || s.serverCwd || null,
               bundle: msg.bundle,
               source: 'live',
               status: 'idle',
@@ -2853,6 +2854,9 @@
               ...s,
               sessionId: msg.session_id,
               cwd: msg.cwd || '~',
+              // Track the server's canonical CWD (may differ from what we
+              // sent if the server expanded ~ or resolved symlinks).
+              serverCwd: msg.cwd || s.serverCwd || null,
               bundle: msg.bundle,
               source: 'live',
               status: 'idle',
@@ -3160,6 +3164,31 @@
         }
 
         case 'command_result': {
+          // When the /cwd command succeeds, update session state with the
+          // new session_id and cwd so subsequent prompts go to the correct
+          // backend session.
+          if (msg.command === 'cwd' && msg.result && !msg.result.error) {
+            const newCwd = msg.result.cwd;
+            const newSid = msg.result.session_id;
+            if (isActiveStream) {
+              if (newSid) setSessionId(newSid);
+              if (newCwd) setCwd(newCwd);
+            }
+            if (ownerKey) {
+              setSessions(prev => {
+                const next = new Map(prev);
+                const s = next.get(ownerKey);
+                if (s) {
+                  const patch = {};
+                  if (newSid) patch.sessionId = newSid;
+                  if (newCwd) { patch.cwd = newCwd; patch.serverCwd = newCwd; }
+                  next.set(ownerKey, { ...s, ...patch });
+                }
+                return next;
+              });
+            }
+            break;  // Skip the system message for silent CWD updates
+          }
           const fmt = formatCommandResult(msg.command, msg.result);
           const item = {
             id: makeId(), type: 'text', role: 'system',
@@ -3225,7 +3254,7 @@
           if (!sessionKey) return prev;
           const next = new Map(prev);
           const s = next.get(sessionKey) || {};
-          next.set(sessionKey, { ...s, ws, cwd: s.cwd || requestedCwd });
+          next.set(sessionKey, { ...s, ws, cwd: s.cwd || requestedCwd, serverCwd: requestedCwd });
           return next;
         });
         ws.send(JSON.stringify({ type: 'create_session', cwd: requestedCwd, bundle: null }));
@@ -3645,6 +3674,22 @@
         return;
       }
 
+      // If the user edited the CWD on a draft session, reconcile with the
+      // server before sending anything.  The /cwd command is processed
+      // sequentially on the same WebSocket so the session will be recreated
+      // with the new directory before the prompt (or server-side command)
+      // that follows.  No optimistic update here — serverCwd is updated
+      // when the command_result arrives from the server.
+      const isDraft = activeSession
+        && activeSession.source !== 'history'
+        && (activeSession.turnCount || 0) === 0;
+      if (isDraft && activeSession.serverCwd != null) {
+        const currentCwd = (defaultCwdRef.current || '').trim() || '~';
+        if (currentCwd !== activeSession.serverCwd) {
+          activeWs.send(JSON.stringify({ type: 'command', name: 'cwd', args: [currentCwd] }));
+        }
+      }
+
       // Client-side slash commands
       if (content.startsWith('/')) {
         const parts = content.trim().split(/\s+/);
@@ -3822,7 +3867,7 @@
         setSessions(prev => {
           const next = new Map(prev);
           const cur = next.get(key) || {};
-          next.set(key, { ...cur, ws, status: 'idle' });
+          next.set(key, { ...cur, ws, status: 'idle', serverCwd: requestedCwd });
           return next;
         });
       };
@@ -4335,6 +4380,26 @@
       const normalized = (rawCwd || '').trim() || '~';
       defaultCwdRef.current = normalized;
       setDefaultCwd(normalized);
+
+      // For draft sessions, also update the displayed cwd and session data
+      // so the metadata view stays consistent if the draft editor hides.
+      // Server-side reconciliation is deferred to sendMessage() to avoid
+      // session churn from repeated edits.
+      const key = activeKeyRef.current;
+      if (!key) return;
+      const session = sessionsRef.current.get(key);
+      if (!session) return;
+      const isDraft = session.source !== 'history' && (session.turnCount || 0) === 0;
+      if (!isDraft) return;
+      if (normalized === (session.cwd || '~')) return;
+
+      setCwd(normalized);
+      setSessions(prev => {
+        const next = new Map(prev);
+        const s = next.get(key);
+        if (s) next.set(key, { ...s, cwd: normalized });
+        return next;
+      });
     }, []);
 
     const startPaneResize = useCallback((pane, e) => {
@@ -4675,6 +4740,10 @@
                         onInput=${e => {
                           defaultCwdRef.current = e.target.value;
                           setDefaultCwd(e.target.value);
+                          // Keep displayed cwd in sync so the metadata view
+                          // shows the edited value if the draft editor hides
+                          // (e.g. when executing becomes true on send).
+                          setCwd(e.target.value);
                         }}
                         onBlur=${e => applyDraftCwd(e.target.value)}
                       />


### PR DESCRIPTION
## Bug

When a user edits the "New Session CWD" text box on a draft session and sends a message, the displayed CWD reverts to the old/default value. The server-side session also retains the stale CWD.

## Root Cause

The CWD input and the session metadata display use two different state variables:
- `defaultCwd` — shown in the editable input (draft sessions)
- `cwd` — shown in the read-only metadata display (active sessions)

When the user edits the CWD input, only `defaultCwd` was updated. The session was already created on the server with the old CWD. When the user sends a message, `executing` becomes `true`, which hides the input and shows the metadata display — which still has the old `cwd` value.

Additionally, the server-side session retained the original CWD from `create_session`, so the session ran in the wrong directory.

## Approach

- **Local state sync during editing** — `applyDraftCwd` and `onInput` now keep `cwd` state and the session map in sync so the metadata view always reflects the user's edit.
- **Deferred server reconciliation at send time** — `sendMessage` compares `defaultCwdRef` against the per-session `serverCwd` and sends a `/cwd` command only when they differ. This avoids session churn from repeated edits.
- **Per-session `serverCwd` tracking** — stored in the sessions Map (not a global ref) so multi-session scenarios stay correct. Updated by `session_created` (server's canonical expanded path) and `command_result` for `/cwd`.

## Changes

### Frontend (`index.html`)

1. **`session_created` handler** (both active and background paths) — records `serverCwd` on the session from the server's canonical response (handles `~` expansion, symlink resolution).

2. **`command_result` handler** — for `/cwd` results, silently updates `sessionId`, `cwd`, and `serverCwd` on the session so subsequent prompts target the correct backend session.

3. **`connect()` and `newSession()` ws.onopen** — set `serverCwd` on the session when `create_session` is sent.

4. **`sendMessage`** — before the first interaction on a draft session, checks `defaultCwdRef.current !== activeSession.serverCwd` and sends `/cwd` to reconcile. No optimistic update — `serverCwd` is only updated when the server confirms via `command_result`.

5. **`applyDraftCwd` (onBlur)** — updates `cwd` state and session map locally. Server reconciliation is deferred to send time.

6. **`onInput`** — keeps `cwd` state in sync during typing.

### Server (`connection.py`)

7. **`/cwd` command handler** — returns `str(info.working_dir)` (resolved path) instead of raw user input, matching `session_created` behavior.

8. **`/cwd` command handler** — adds null-byte validation matching the `create_session` handler.

## Testing

- All 27 relevant tests pass (verified with only PR changes, pre-existing unstaged work stashed)
- Scenarios covered:
  - Create session -> edit CWD -> send message -> CWD persists correctly
  - Create session -> send immediately (no edit) -> no `/cwd` command sent
  - Create session -> edit CWD multiple times -> send -> single reconciliation with final value
  - Multi-session: switching sessions does not corrupt other sessions' `serverCwd`
  - Server expands `~` paths: `serverCwd` tracks the expanded canonical form