### PR TITLE
fix: include CSS and WOFF2 files in package data

### DIFF
--- a/distro-server/pyproject.toml
+++ b/distro-server/pyproject.toml
@@ -44,7 +44,7 @@ amp-distro = "amplifier_distro.cli:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-amplifier_distro = ["**/*.html", "**/*.js", "**/*.mjs", "**/*.svg"]
+amplifier_distro = ["**/*.html", "**/*.css", "**/*.js", "**/*.mjs", "**/*.svg", "**/*.woff2"]
 
 # -- Code Quality ----------------------------------------------
 [tool.ruff]


### PR DESCRIPTION
CSS and font files were missing from the `[tool.setuptools.package-data]` globs in `pyproject.toml`, causing 404 errors on fresh pip/uv installs.

The glob list only included `*.html`, `*.js`, `*.mjs`, `*.svg` — so `amplifier-theme.css`, `styles.css`, and all bundled WOFF2 fonts were silently excluded from the installed package.

This was a pre-existing issue that became visible after #115 added new CSS imports and font files.

**Change:**
```toml
# Before
amplifier_distro = ["**/*.html", "**/*.js", "**/*.mjs", "**/*.svg"]

# After
amplifier_distro = ["**/*.html", "**/*.css", "**/*.js", "**/*.mjs", "**/*.svg", "**/*.woff2"]
```