### PR TITLE
Update Tutorial and Stories links to withamplifier.com

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
+++ b/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
@@ -1420,9 +1420,9 @@ function renderEnvironment(detect) {
 function renderFooter() {
   return '<div class="footer-links">'
     + '<a href="/apps/install-wizard/">Setup Wizard</a>'
-    + '<a href="https://ramparte.github.io/amplifier-tutorial" target="_blank">Tutorial</a>'
+    + '<a href="https://withamplifier.com/learn" target="_blank">Tutorial</a>'
     + '<a href="https://github.com/microsoft/amplifier/tree/main/docs" target="_blank">Docs</a>'
-    + '<a href="https://ramparte.github.io/amplifier-stories" target="_blank">Stories</a>'
+    + '<a href="https://withamplifier.com/stories" target="_blank">Stories</a>'
     + '</div>';
 }
 

--- a/distro-server/src/amplifier_distro/server/static/index.html
+++ b/distro-server/src/amplifier_distro/server/static/index.html
@@ -51,11 +51,11 @@
 
   <div class="section-title">Learn More</div>
   <div class="links">
-    <a href="https://ramparte.github.io/amplifier-tutorial" target="_blank">Tutorial</a>
+    <a href="https://withamplifier.com/learn" target="_blank">Tutorial</a>
     <span class="sep">&middot;</span>
     <a href="https://github.com/microsoft/amplifier/tree/main/docs" target="_blank">Documentation</a>
     <span class="sep">&middot;</span>
-    <a href="https://ramparte.github.io/amplifier-stories" target="_blank">Stories</a>
+    <a href="https://withamplifier.com/stories" target="_blank">Stories</a>
   </div>
 
   <div class="footer">

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,6 @@
 #   Dockerfile:
 #     RUN bash scripts/install.sh
 #
-#   curl | bash (standalone):
-#     curl -fsSL https://raw.githubusercontent.com/ramparte/amplifier-distro/main/scripts/install.sh | bash
-#
 #   Local developer:
 #     git clone ... && cd amplifier-distro && bash scripts/install.sh
 #


### PR DESCRIPTION
## Summary

- Updated Tutorial and Stories links in the home page (index.html) and settings footer (settings.html) from old ramparte.github.io URLs to withamplifier.com/learn and withamplifier.com/stories
- Removed commented-out old ramparte curl install URL from install.sh
- Documentation link left unchanged (already points to microsoft/amplifier)

## Test plan

- [x] Links updated in index.html
- [x] Links updated in settings.html  
- [x] Removed old install.sh commented URL
- [x] Documentation link verification complete