### PR TITLE
fix: wire WatchdogSettings to runtime watchdog code

### DIFF
--- a/distro-server/src/amplifier_distro/cli.py
+++ b/distro-server/src/amplifier_distro/cli.py
@@ -49,7 +49,9 @@ def main() -> None:
 
 @main.command("serve")
 @click.option(
-    "--host", default="0.0.0.0", help="Bind host (use 127.0.0.1 to restrict to localhost)"
+    "--host",
+    default="0.0.0.0",
+    help="Bind host (use 127.0.0.1 to restrict to localhost)",
 )
 @click.option(
     "--port", default=conventions.SERVER_DEFAULT_PORT, type=int, help="Bind port"
@@ -290,6 +292,15 @@ def service_cmd_status() -> None:
 )
 def watchdog_cmd(host: str, port: int, supervised: bool) -> None:
     """Run the health watchdog (for service supervision — not user-facing)."""
+    from . import distro_settings
     from .server.watchdog import run_watchdog_loop
 
-    run_watchdog_loop(host=host, port=port, supervised=supervised)
+    wd = distro_settings.load().watchdog
+    run_watchdog_loop(
+        host=host,
+        port=port,
+        supervised=supervised,
+        check_interval=wd.check_interval,
+        restart_after=wd.restart_after,
+        max_restarts=wd.max_restarts,
+    )

--- a/distro-server/src/amplifier_distro/server/cli.py
+++ b/distro-server/src/amplifier_distro/server/cli.py
@@ -248,39 +248,46 @@ def watchdog_group(ctx: click.Context) -> None:
 )
 @click.option(
     "--check-interval",
-    default=30,
+    default=None,
     type=int,
-    help="Seconds between health checks",
+    help="Seconds between health checks (default: from settings or 30)",
 )
 @click.option(
     "--restart-after",
-    default=300,
+    default=None,
     type=int,
-    help="Seconds of sustained downtime before restart",
+    help="Seconds of sustained downtime before restart (default: from settings or 300)",
 )
 @click.option(
     "--max-restarts",
-    default=5,
+    default=None,
     type=int,
-    help="Max restart attempts (0 = unlimited)",
+    help="Max restart attempts, 0 = unlimited (default: from settings or 5)",
 )
 @click.option("--apps-dir", default=None, help="Server apps directory")
 @click.option("--dev", is_flag=True, help="Server dev mode")
 def watchdog_start(
     host: str,
     port: int,
-    check_interval: int,
-    restart_after: int,
-    max_restarts: int,
+    check_interval: int | None,
+    restart_after: int | None,
+    max_restarts: int | None,
     apps_dir: str | None,
     dev: bool,
 ) -> None:
     """Start the watchdog as a background process."""
+    from amplifier_distro import distro_settings
     from amplifier_distro.server.watchdog import is_watchdog_running, start_watchdog
 
     if is_watchdog_running():
         click.echo("Watchdog is already running.", err=True)
         raise SystemExit(1)
+
+    # CLI flags override persisted settings; settings override hardcoded defaults.
+    wd = distro_settings.load().watchdog
+    check_interval = check_interval if check_interval is not None else wd.check_interval
+    restart_after = restart_after if restart_after is not None else wd.restart_after
+    max_restarts = max_restarts if max_restarts is not None else wd.max_restarts
 
     pid = start_watchdog(
         host=host,


### PR DESCRIPTION
Closes microsoft/amplifier-distro#105

## Problem

`WatchdogSettings` (`check_interval`, `restart_after`, `max_restarts`) could be persisted to `settings.yaml` via the API, but no runtime code ever read those values back. Both CLI entry points used hardcoded Python defaults, making the settings a data island with no consumer.

## Fix

**`cli.py`** — The hidden `watchdog_cmd()` (the primary entry point used by systemd/launchd service units) now loads `distro_settings.load().watchdog` and passes the three timing values to `run_watchdog_loop()`.

**`server/cli.py`** — The `serve watchdog start` command's CLI options now default to `None` instead of hardcoded values. The function body loads persisted settings as fallback, giving a clean override chain:

```
CLI flags (explicit) > persisted settings.yaml > hardcoded defaults
```

## What this does NOT include

**No UI changes.** The watchdog is described as "not user-facing" in CLI help. These are operational settings that belong in YAML-only config. Power users who discover `~/.amplifier-distro/settings.yaml` and edit the watchdog section will now see their changes take effect — that's the fix.

## Testing

Both entry points are covered by existing tests. The change is additive — when no settings file exists, `distro_settings.load()` returns the dataclass defaults (30/300/5), which are identical to the previously-hardcoded values. Zero behavior change for users who haven't customized settings.