### PR TITLE
fix: make settings persistence crash-safe and concurrency-safe

### DIFF
--- a/distro-server/src/amplifier_distro/distro_settings.py
+++ b/distro-server/src/amplifier_distro/distro_settings.py
@@ -17,8 +17,11 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+import tempfile
+import threading
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -28,6 +31,10 @@ import yaml
 from amplifier_distro import conventions
 
 logger = logging.getLogger(__name__)
+
+# Guards the load/modify/save cycle so concurrent API requests
+# (settings page, install wizard, Slack setup) cannot clobber each other.
+_settings_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -165,12 +172,29 @@ def load() -> DistroSettings:
 
 
 def save(settings: DistroSettings) -> Path:
-    """Persist distro settings to disk. Returns the file path."""
+    """Persist distro settings to disk atomically. Returns the file path.
+
+    Writes to a temporary file in the same directory then renames it into
+    place.  On POSIX the rename is atomic, so a crash mid-write can never
+    leave a truncated settings file.
+    """
     path = _settings_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        yaml.dump(asdict(settings), default_flow_style=False, sort_keys=False)
-    )
+    content = yaml.dump(asdict(settings), default_flow_style=False, sort_keys=False)
+
+    # Write to a temp file in the same directory (same filesystem) so
+    # os.replace() is guaranteed to be atomic on POSIX.
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".settings-", suffix=".yaml.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
     return path
 
 
@@ -179,19 +203,24 @@ def update(section: str | None = None, **kwargs: Any) -> DistroSettings:
 
     If *section* is given (e.g. ``"slack"``), kwargs are applied to that
     nested dataclass.  Otherwise they are applied to the root.
+
+    The entire load/modify/save cycle is protected by ``_settings_lock``
+    so concurrent callers (settings page, install wizard, Slack setup)
+    cannot clobber each other's writes.
     """
-    settings = load()
-    if section is not None:
-        nested = getattr(settings, section)
-        for key, value in kwargs.items():
-            if hasattr(nested, key):
-                setattr(nested, key, value)
-    else:
-        for key, value in kwargs.items():
-            if hasattr(settings, key):
-                setattr(settings, key, value)
-    save(settings)
-    return settings
+    with _settings_lock:
+        settings = load()
+        if section is not None:
+            nested = getattr(settings, section)
+            for key, value in kwargs.items():
+                if hasattr(nested, key):
+                    setattr(nested, key, value)
+        else:
+            for key, value in kwargs.items():
+                if hasattr(settings, key):
+                    setattr(settings, key, value)
+        save(settings)
+        return settings
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes microsoft/amplifier-distro#106

## Problem

`distro_settings.py` had two persistence bugs:

1. **No atomic writes** — `save()` used `path.write_text()` directly. A crash or kill mid-write leaves a truncated settings file. Since `load()` silently returns defaults when it can't parse the file, the data loss is invisible — the user loses their settings without any error.

2. **No write locking** — `update()` performs load/modify/save with no concurrency protection. Multiple concurrent API callers (the settings page, install wizard, and Slack setup all write settings) can race, with one silently clobbering the other's changes.

## Fix

Single file change: `distro_settings.py`

**Atomic writes:** `save()` now writes to a temporary file in the same directory via `tempfile.mkstemp()`, calls `fsync()`, then uses `os.replace()` to atomically swap it into place. On POSIX, `os.replace()` is atomic — a crash at any point either leaves the old file intact or completes the new one. The temp file is cleaned up on error.

**Write locking:** Added a module-level `threading.Lock` (`_settings_lock`). The `update()` method holds the lock for the entire load/modify/save cycle, preventing concurrent API requests from interleaving. A `threading.Lock` (not `asyncio.Lock`) is correct here because the I/O is synchronous and fast — the lock is held only for the duration of a YAML read/write.

## What's unchanged

- `load()` is not locked — concurrent reads are safe (file reads are atomic at the OS level for small files, and the worst case is reading a slightly stale snapshot)
- `save()` is not independently locked — callers who need read-modify-write should use `update()`, which holds the lock. Direct `save()` calls are atomic at the file level.
- `export_to_env()` is unchanged