### PR TITLE
fix: implement event queue fanout for multi-client sessions

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/chat/connection.py
+++ b/distro-server/src/amplifier_distro/server/apps/chat/connection.py
@@ -123,6 +123,13 @@ class ChatConnection:
             non_exec = [t for t in self._tasks if t is not self._active_execution]
             if non_exec:
                 await asyncio.gather(*non_exec, return_exceptions=True)
+            # Remove this connection's event queue from the backend fanout set
+            # so the dead queue doesn't accumulate or generate spurious
+            # QueueFull errors after disconnect.
+            if self._session_id:
+                dequeue = getattr(self._backend, "dequeue_client", None)
+                if dequeue is not None:
+                    dequeue(self._session_id, self.event_queue)
             # Stop the fanout loop gracefully via sentinel first, then
             # force-cancel as fallback. Using put_nowait avoids blocking
             # if the queue is full (which happens when the fanout died
@@ -137,9 +144,9 @@ class ChatConnection:
                     await fanout_task
             # Do NOT call _cleanup_hook() here. Hooks are intentionally left
             # registered so the still-running execution's events can be
-            # redirected to the new queue via QueueHolder swap on reconnect.
-            # _cleanup_hook() is still called from _dispatch_command (bundle/cwd)
-            # for explicit session replacement.
+            # delivered to any remaining connected clients via the fanout
+            # holder.  _cleanup_hook() is still called from _dispatch_command
+            # (bundle/cwd) for explicit session replacement.
 
     def _cleanup_hook(self) -> None:
         """Unregister the hook if one is registered. Always safe to call.

--- a/distro-server/src/amplifier_distro/server/protocol_adapters.py
+++ b/distro-server/src/amplifier_distro/server/protocol_adapters.py
@@ -84,16 +84,21 @@ class ApprovalSystem:
 
 
 class QueueDisplaySystem:
-    """Display system that pushes messages to an asyncio.Queue.
+    """Display system that pushes messages to an asyncio.Queue or _QueueHolder.
 
     Satisfies the display protocol expected by the coordinator.
     Every show_message() call enqueues a ("display_message", {...}) tuple.
+
+    Accepts any object with a compatible ``put_nowait(item)`` method, which
+    includes both ``asyncio.Queue`` and the ``_QueueHolder`` fanout wrapper
+    used by ``FoundationBackend``.  Passing a ``_QueueHolder`` means display
+    messages are broadcast to all currently-connected clients automatically.
     """
 
     def __init__(
         self,
-        queue: asyncio.Queue,
-        nesting_depth: int = 0,  # type: ignore[type-arg]
+        queue: Any,  # asyncio.Queue or _QueueHolder (duck-typed via put_nowait)
+        nesting_depth: int = 0,
     ) -> None:
         self._queue = queue
         self._nesting_depth = nesting_depth

--- a/distro-server/src/amplifier_distro/server/session_backend.py
+++ b/distro-server/src/amplifier_distro/server/session_backend.py
@@ -328,22 +328,52 @@ class MockBackend:
 
 
 class _QueueHolder:
-    """Mutable wrapper so hook closures can have their target queue swapped.
+    """Mutable wrapper supporting multiple queue targets for event fanout.
 
-    Hook closures capture this holder by reference. On reconnect, swapping
-    ``holder.queue`` redirects all events to the new connection's queue
-    without re-registering hooks on the coordinator. In single-threaded
-    asyncio, no ``await`` occurs between the swap and any ``put_nowait``
-    call, so cooperative scheduling cannot interleave them.
+    Hook closures capture this holder by reference. Queues are added with
+    ``add()`` on client connect and removed with ``remove()`` on disconnect
+    without re-registering hooks on the coordinator.
+
+    ``put_nowait()`` broadcasts to **all** registered queues. It raises
+    ``asyncio.QueueFull`` only when every queue is full (or the set is
+    empty), preserving the contract callers rely on for drop-logging.
+
+    In single-threaded asyncio, no ``await`` occurs between queue mutations
+    and any ``put_nowait`` call, so cooperative scheduling cannot interleave
+    them.
     """
 
-    __slots__ = ("queue",)
+    __slots__ = ("_queues",)
 
     def __init__(self, queue: asyncio.Queue) -> None:
-        self.queue = queue
+        self._queues: set[asyncio.Queue] = {queue}
+
+    def add(self, queue: asyncio.Queue) -> None:
+        """Add a queue to the fanout set (client connect / reconnect)."""
+        self._queues.add(queue)
+
+    def remove(self, queue: asyncio.Queue) -> None:
+        """Remove a queue from the fanout set (client disconnect)."""
+        self._queues.discard(queue)
 
     def put_nowait(self, item: Any) -> None:
-        self.queue.put_nowait(item)
+        """Broadcast *item* to all registered queues.
+
+        Silently skips individual full queues so a slow client cannot block
+        delivery to faster ones.  Raises ``asyncio.QueueFull`` only when
+        every queue is full or the set is empty (no delivery was possible).
+        """
+        queues = list(self._queues)
+        if not queues:
+            raise asyncio.QueueFull
+        failed = 0
+        for q in queues:
+            try:
+                q.put_nowait(item)
+            except asyncio.QueueFull:
+                failed += 1
+        if failed == len(queues):
+            raise asyncio.QueueFull
 
 
 class FoundationBackend:
@@ -402,9 +432,10 @@ class FoundationBackend:
         is provided. All three closures push (event_name, data) tuples
         to the same queue via a _QueueHolder indirection.
 
-        On reconnect (session already in _wired_sessions), swaps the queue
-        reference in the existing holder so all hook closures instantly
-        target the new queue without re-registration on the coordinator.
+        On reconnect (session already in _wired_sessions), adds the new
+        queue to the existing holder's fanout set so all connected clients
+        continue receiving events — the originating client's queue is NOT
+        replaced, preventing it from being starved of the completion signal.
 
         Returns an unregister callable that removes all registered hooks and
         removes the session from _wired_sessions.
@@ -417,25 +448,24 @@ class FoundationBackend:
         coordinator = session.coordinator
 
         if session_id in self._wired_sessions:
-            # Already wired — swap the queue target so existing hook closures
-            # instantly push to the new connection's queue. No hook
-            # unregister/re-register needed. Safe in single-threaded asyncio:
-            # no await between the swap and any put_nowait call.
+            # Already wired — add the new queue to the fanout set so the
+            # new client also receives events.  The existing clients' queues
+            # remain in the set: they keep getting events and will still
+            # receive the orchestrator:complete / prompt_complete signal.
+            # No hook unregister/re-register needed.  Safe in single-threaded
+            # asyncio: no await between the add() and any put_nowait call.
             holder = self._queue_holders.get(session_id)
             if holder is not None:
-                holder.queue = event_queue
+                holder.add(event_queue)
                 logger.debug(
-                    "Swapped event queue for session %s (reconnect)", session_id
+                    "Added event queue for session %s (fanout reconnect)", session_id
                 )
 
-            # Also update display system to use the new queue
-            display = QueueDisplaySystem(event_queue)
-            if hasattr(coordinator, "set"):
-                coordinator.set("display", display)
+            # The display system already points to the holder, which now
+            # broadcasts to the new queue — no replacement needed.
 
-            # Update approval system — route through holder for consistency
-            # with the initial-wire path (avoids stale closure if approval
-            # system is ever cached outside the coordinator).
+            # Approval system: rebuild so on_approval_request_rewire closure
+            # references the updated holder (handles stale-closure edge cases).
             def _on_approval_request_rewire(
                 request_id: str,
                 prompt: str,
@@ -443,6 +473,8 @@ class FoundationBackend:
                 timeout: float,
                 default: str,
             ) -> None:
+                if holder is None:
+                    return
                 try:
                     holder.put_nowait(
                         (
@@ -474,7 +506,8 @@ class FoundationBackend:
         self._wired_sessions.add(session_id)
 
         # Create a mutable queue holder — hook closures capture this by
-        # reference, so swapping holder.queue on reconnect retargets them.
+        # reference.  On reconnect, additional queues are added via
+        # holder.add() so all connected clients receive events (fanout).
         holder = _QueueHolder(event_queue)
         self._queue_holders[session_id] = holder
 
@@ -548,8 +581,9 @@ class FoundationBackend:
             for evt, exc in failed_evts:
                 logger.warning("  hook registration failed [%s]: %s", evt, exc)
 
-        # 2. Display system — display messages to queue
-        display = QueueDisplaySystem(event_queue)
+        # 2. Display system — display messages via holder so future clients
+        # added by holder.add() automatically receive display messages too.
+        display = QueueDisplaySystem(holder)  # type: ignore[arg-type]
         if hasattr(coordinator, "set"):
             coordinator.set("display", display)
 
@@ -1066,6 +1100,22 @@ class FoundationBackend:
         """
         handle = self._sessions.get(session_id)
         return handle.hook_unregister if handle else None
+
+    def dequeue_client(self, session_id: str, queue: asyncio.Queue) -> None:
+        """Remove a client's event queue from the fanout set for a session.
+
+        Called when a WebSocket client disconnects so the dead queue is
+        evicted from the ``_QueueHolder`` and does not accumulate memory or
+        generate spurious ``QueueFull`` errors on subsequent events.
+
+        Safe to call even if the session or holder no longer exists (no-op).
+        """
+        holder = self._queue_holders.get(session_id)
+        if holder is not None:
+            holder.remove(queue)
+            logger.debug(
+                "Removed event queue for session %s (client disconnect)", session_id
+            )
 
     def get_session_config(self, session_id: str) -> dict[str, Any] | None:
         """Return the mount-plan config dict for a live session."""

--- a/distro-server/tests/test_chat_display_messages.py
+++ b/distro-server/tests/test_chat_display_messages.py
@@ -53,6 +53,8 @@ class TestDisplayMessageQueueWiring:
         backend._ended_sessions = set()
         backend._wired_sessions = set()
         backend._approval_systems = {}
+        backend._queue_holders = {}
+        backend._event_forwarders = {}
 
         q: asyncio.Queue = asyncio.Queue()
 
@@ -88,6 +90,8 @@ class TestDisplayMessageQueueWiring:
         backend._ended_sessions = set()
         backend._wired_sessions = set()
         backend._approval_systems = {}
+        backend._queue_holders = {}
+        backend._event_forwarders = {}
 
         with patch("asyncio.create_task"):
             await backend.create_session(working_dir="~")  # no event_queue

--- a/distro-server/tests/test_session_backend.py
+++ b/distro-server/tests/test_session_backend.py
@@ -1460,7 +1460,7 @@ class TestFoundationBackendUpdateSessionMetadata:
 
 
 class TestQueueRewire:
-    """Tests for queue holder rewire on reconnect (BUG-2, issue #60)."""
+    """Tests for queue holder fanout on reconnect."""
 
     def _make_wired_backend(self):
         """Build a FoundationBackend with a wired session for testing."""
@@ -1496,57 +1496,61 @@ class TestQueueRewire:
         session.coordinator = coordinator
         return session
 
-    @pytest.mark.asyncio
-    async def test_events_flow_to_new_queue_after_reconnect(self):
-        """After reconnect, on_stream must push events to the NEW queue."""
-        backend = self._make_wired_backend()
-        session = self._make_mock_session()
-        session_id = "test-rewire"
-
-        # Simulate _SessionHandle
-        handle = MagicMock()
-        handle.session = session
-        handle.hook_unregister = None
-        backend._sessions[session_id] = handle
-
-        # First wire: create with queue_a
-        queue_a = asyncio.Queue()
-        unregister = backend._wire_event_queue(session, session_id, queue_a)
-        handle.hook_unregister = unregister
-
-        # Capture the on_stream handler from the hooks.register calls
+    def _capture_on_stream(self, session):
+        """Extract the on_stream hook handler from mock register calls."""
         register_calls = session.coordinator.hooks.register.call_args_list
-        on_stream_handler = None
         for call in register_calls:
             args = call[0]
             if len(args) >= 2 and callable(args[1]):
-                on_stream_handler = args[1]
-                break
-        assert on_stream_handler is not None, "on_stream hook must be registered"
+                return args[1]
+        raise AssertionError("on_stream hook must be registered")
+
+    # ------------------------------------------------------------------
+    # Fanout: both original and reconnected clients receive events
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_events_fanout_to_both_queues_after_reconnect(self):
+        """After reconnect, events must fan out to BOTH queues (not just new)."""
+        backend = self._make_wired_backend()
+        session = self._make_mock_session()
+        session_id = "test-fanout"
+
+        handle = MagicMock()
+        handle.session = session
+        handle.hook_unregister = None
+        backend._sessions[session_id] = handle
+
+        # First wire: create with queue_a (BrowserA)
+        queue_a = asyncio.Queue()
+        unregister = backend._wire_event_queue(session, session_id, queue_a)
+        handle.hook_unregister = unregister
+
+        on_stream = self._capture_on_stream(session)
 
         # Verify events go to queue_a
-        await on_stream_handler("test:event", {"data": "first"})
+        await on_stream("test:event", {"data": "first"})
         assert queue_a.qsize() == 1
-        event = queue_a.get_nowait()
-        assert event == ("test:event", {"data": "first"})
+        queue_a.get_nowait()
 
-        # Reconnect: wire with queue_b (simulates page refresh)
+        # Reconnect: wire with queue_b (BrowserB)
         queue_b = asyncio.Queue()
         backend._wire_event_queue(session, session_id, queue_b)
 
-        # Now events should flow to queue_b, NOT queue_a
-        await on_stream_handler("test:event", {"data": "second"})
-        assert queue_b.qsize() == 1, "Events must flow to NEW queue after reconnect"
-        assert queue_a.qsize() == 0, "Old queue must NOT receive events after reconnect"
-        event = queue_b.get_nowait()
-        assert event == ("test:event", {"data": "second"})
+        # Events must fan out to BOTH queues
+        await on_stream("test:event", {"data": "second"})
+        assert queue_a.qsize() == 1, "Original queue must still receive events"
+        assert queue_b.qsize() == 1, "New queue must also receive events"
+        assert queue_a.get_nowait() == ("test:event", {"data": "second"})
+        assert queue_b.get_nowait() == ("test:event", {"data": "second"})
 
     @pytest.mark.asyncio
-    async def test_display_system_rewired_on_reconnect(self):
-        """Display system must use the new queue after reconnect."""
+    async def test_display_system_uses_holder_for_fanout(self):
+        """Display system must be wired to the holder, not a raw queue."""
+
         backend = self._make_wired_backend()
         session = self._make_mock_session()
-        session_id = "test-display-rewire"
+        session_id = "test-display-holder"
 
         handle = MagicMock()
         handle.session = session
@@ -1554,18 +1558,24 @@ class TestQueueRewire:
         backend._sessions[session_id] = handle
 
         queue_a = asyncio.Queue()
-        unregister = backend._wire_event_queue(session, session_id, queue_a)
-        handle.hook_unregister = unregister
+        backend._wire_event_queue(session, session_id, queue_a)
 
-        # Reconnect with queue_b
+        # The initial display system should have been set with the holder
+        set_calls = session.coordinator.set.call_args_list
+        display_calls = [c for c in set_calls if c[0][0] == "display"]
+        assert len(display_calls) >= 1, "Display system must be set on initial wire"
+
+        # On reconnect, display should NOT be re-set (holder already fans out)
         queue_b = asyncio.Queue()
         backend._wire_event_queue(session, session_id, queue_b)
 
-        # Display system should have been re-set on coordinator
-        set_calls = session.coordinator.set.call_args_list
-        display_calls = [c for c in set_calls if c[0][0] == "display"]
-        # At least 2 display calls: one from first wire, one from reconnect
-        assert len(display_calls) >= 2, "Display system must be rewired on reconnect"
+        display_calls_after = [
+            c for c in session.coordinator.set.call_args_list if c[0][0] == "display"
+        ]
+        # Should still be just the one initial call — reconnect doesn't re-set
+        assert len(display_calls_after) == len(display_calls), (
+            "Display system should not be re-set on reconnect (holder fans out)"
+        )
 
     @pytest.mark.asyncio
     async def test_queue_holder_cleaned_up_on_unregister(self):
@@ -1591,8 +1601,8 @@ class TestQueueRewire:
         assert session_id not in backend._wired_sessions
 
     @pytest.mark.asyncio
-    async def test_rapid_reconnect_cycles_work(self):
-        """Multiple rapid reconnects must all route events to the latest queue."""
+    async def test_rapid_reconnect_cycles_fanout_to_all(self):
+        """Multiple rapid reconnects must fan out events to all queues."""
         backend = self._make_wired_backend()
         session = self._make_mock_session()
         session_id = "test-rapid"
@@ -1607,17 +1617,165 @@ class TestQueueRewire:
         unregister = backend._wire_event_queue(session, session_id, queue_1)
         handle.hook_unregister = unregister
 
-        # Capture on_stream
-        on_stream = session.coordinator.hooks.register.call_args_list[0][0][1]
+        on_stream = self._capture_on_stream(session)
 
         # 5 rapid reconnects
-        latest_queue = None
-        for i in range(5):
-            latest_queue = asyncio.Queue()
-            backend._wire_event_queue(session, session_id, latest_queue)
+        all_queues = [queue_1]
+        for _ in range(5):
+            q = asyncio.Queue()
+            all_queues.append(q)
+            backend._wire_event_queue(session, session_id, q)
 
-        # Events should only go to the latest queue
+        # Events should fan out to ALL 6 queues
         await on_stream("test:event", {"cycle": "final"})
-        assert latest_queue is not None
-        assert latest_queue.qsize() == 1
-        assert queue_1.qsize() == 0
+        for i, q in enumerate(all_queues):
+            assert q.qsize() == 1, f"Queue {i} must receive the event"
+
+    # ------------------------------------------------------------------
+    # dequeue_client: cleanup on disconnect
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_dequeue_client_removes_queue_from_fanout(self):
+        """Disconnected clients must stop receiving events."""
+        backend = self._make_wired_backend()
+        session = self._make_mock_session()
+        session_id = "test-dequeue"
+
+        handle = MagicMock()
+        handle.session = session
+        handle.hook_unregister = None
+        backend._sessions[session_id] = handle
+
+        queue_a = asyncio.Queue()
+        queue_b = asyncio.Queue()
+        backend._wire_event_queue(session, session_id, queue_a)
+        backend._wire_event_queue(session, session_id, queue_b)
+
+        on_stream = self._capture_on_stream(session)
+
+        # Both receive events
+        await on_stream("test:event", {"data": "both"})
+        assert queue_a.qsize() == 1
+        assert queue_b.qsize() == 1
+        queue_a.get_nowait()
+        queue_b.get_nowait()
+
+        # BrowserA disconnects
+        backend.dequeue_client(session_id, queue_a)
+
+        # Only queue_b should receive events now
+        await on_stream("test:event", {"data": "only-b"})
+        assert queue_a.qsize() == 0, "Dequeued client must not receive events"
+        assert queue_b.qsize() == 1, "Remaining client must still receive events"
+
+    def test_dequeue_client_noop_for_unknown_session(self):
+        """dequeue_client must be safe to call for unknown sessions."""
+        backend = self._make_wired_backend()
+        # Should not raise
+        backend.dequeue_client("nonexistent", asyncio.Queue())
+
+
+class TestQueueHolder:
+    """Unit tests for the _QueueHolder fanout wrapper."""
+
+    def test_single_queue_put_nowait(self):
+        """put_nowait with a single queue delivers the item."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q = asyncio.Queue()
+        holder = _QueueHolder(q)
+        holder.put_nowait(("event", {"data": 1}))
+        assert q.qsize() == 1
+        assert q.get_nowait() == ("event", {"data": 1})
+
+    def test_fanout_to_multiple_queues(self):
+        """put_nowait broadcasts to all registered queues."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q1 = asyncio.Queue()
+        q2 = asyncio.Queue()
+        q3 = asyncio.Queue()
+        holder = _QueueHolder(q1)
+        holder.add(q2)
+        holder.add(q3)
+
+        holder.put_nowait(("event", {"data": "all"}))
+        for q in (q1, q2, q3):
+            assert q.qsize() == 1
+            assert q.get_nowait() == ("event", {"data": "all"})
+
+    def test_remove_stops_delivery(self):
+        """After remove(), that queue no longer receives events."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q1 = asyncio.Queue()
+        q2 = asyncio.Queue()
+        holder = _QueueHolder(q1)
+        holder.add(q2)
+
+        holder.remove(q1)
+        holder.put_nowait(("event", {}))
+        assert q1.qsize() == 0, "Removed queue must not get events"
+        assert q2.qsize() == 1
+
+    def test_remove_unknown_queue_is_noop(self):
+        """remove() with an unknown queue does not raise."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q1 = asyncio.Queue()
+        holder = _QueueHolder(q1)
+        # Should not raise
+        holder.remove(asyncio.Queue())
+
+    def test_put_nowait_empty_set_raises_queue_full(self):
+        """put_nowait on an empty holder raises QueueFull."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q = asyncio.Queue()
+        holder = _QueueHolder(q)
+        holder.remove(q)  # Now empty
+
+        with pytest.raises(asyncio.QueueFull):
+            holder.put_nowait(("event", {}))
+
+    def test_partial_queue_full_still_delivers_to_others(self):
+        """If one queue is full, others still receive the event."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        full_q = asyncio.Queue(maxsize=1)
+        full_q.put_nowait("filler")  # Fill it up
+        normal_q = asyncio.Queue()
+
+        holder = _QueueHolder(full_q)
+        holder.add(normal_q)
+
+        # Should NOT raise — partial delivery is ok
+        holder.put_nowait(("event", {"data": "partial"}))
+        assert normal_q.qsize() == 1
+        assert normal_q.get_nowait() == ("event", {"data": "partial"})
+
+    def test_add_same_queue_twice_delivers_once(self):
+        """Adding the same queue twice must not cause double delivery."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q = asyncio.Queue()
+        holder = _QueueHolder(q)
+        holder.add(q)  # duplicate add — set ignores it
+        holder.put_nowait(("event", {"data": "once"}))
+        assert q.qsize() == 1, "Duplicate add must not cause double delivery"
+
+    def test_all_queues_full_raises_queue_full(self):
+        """If ALL queues are full, put_nowait raises QueueFull."""
+        from amplifier_distro.server.session_backend import _QueueHolder
+
+        q1 = asyncio.Queue(maxsize=1)
+        q2 = asyncio.Queue(maxsize=1)
+        q1.put_nowait("filler")
+        q2.put_nowait("filler")
+
+        holder = _QueueHolder(q1)
+        holder.add(q2)
+
+        with pytest.raises(asyncio.QueueFull):
+            holder.put_nowait(("event", {}))


### PR DESCRIPTION
## Summary

Fixes the issue where a second client connecting to a session would orphan the first client's event queue, leaving the first client stuck in "loading" state forever.

**Root cause:** The `_QueueHolder` used a single mutable `queue` reference that got replaced when a new client connected, permanently orphaning the previous queue.

**Solution:** Replace single queue reference with a `set[asyncio.Queue]` that broadcasts events to all connected clients via fanout.

## Implementation Details

### `session_backend.py`
- `_QueueHolder` rewritten from single mutable `queue` to `set[asyncio.Queue]`
- `put_nowait()` implements fanout broadcast to all registered queues
- Reconnect path calls `holder.add(queue)` instead of replacing queue
- `QueueDisplaySystem(holder)` used for display message fanout
- New `dequeue_client()` method evicts dead queues on disconnect
- Gracefully skips full individual queues; raises `QueueFull` only when all full

### `protocol_adapters.py`
- `QueueDisplaySystem` accepts duck-typed `Any` (both `asyncio.Queue` and `_QueueHolder` satisfy the interface)

### `connection.py`
- `run()` finally block calls `backend.dequeue_client()` on WebSocket disconnect

## Tests

Updated existing tests and added comprehensive new tests:
- 4 existing `TestQueueRewire` tests updated to verify fanout behavior
- 7 new `TestQueueHolder` unit tests (single delivery, fanout, remove, full queue handling)
- 2 new integration tests (`dequeue_client` removes queue, noop for unknown session)
- Added missing mock attributes in `test_chat_display_messages.py`

**Result:** All 132 tests pass ✅

## Test Plan

- [x] Unit tests for `_QueueHolder` fanout logic
- [x] Integration tests for reconnect flow and cleanup
- [x] Existing test suite (132 tests) passes without regression
- [x] All 5 modified files staged and committed (excluding `uv.lock`)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)