### PR TITLE
feat: unified header with auth-aware logout across apps

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
+++ b/distro-server/src/amplifier_distro/server/apps/settings/static/settings.html
@@ -12,6 +12,9 @@
 <!-- Shared theme -->
 <link rel="stylesheet" href="/static/amplifier-theme.css">
 
+<script src="/static/feedback-widget.js"></script>
+<script src="/static/amplifier-header.js"></script>
+
 <style>
 /* ------------------------------------------------------------------ */
 /*  Settings-Specific Styles                                          */
@@ -36,42 +39,6 @@ body {
   padding: 40px;
   width: 100%;
   max-width: 720px;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Header                                                             */
-/* ------------------------------------------------------------------ */
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 32px;
-}
-
-.header h1 {
-  font-size: 24px;
-  font-weight: 700;
-}
-
-.header-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.header a {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--signal);
-  text-decoration: none;
-  padding: 8px 16px;
-  border: 1px solid var(--signal);
-  border-radius: var(--radius-button);
-  transition: all var(--duration-fast) var(--ease-out);
-}
-
-.header a:hover {
-  background: var(--signal);
-  color: #fff;
 }
 
 /* ------------------------------------------------------------------ */
@@ -800,6 +767,16 @@ body {
 </head>
 <body>
 
+<div id="app-header" style="width:100%;max-width:720px;"></div>
+<script>
+  AmplifierHeader.init({
+    appName: 'settings',
+    backLink: { url: '/', label: 'Dashboard' },
+    feedbackApp: 'settings',
+    container: document.getElementById('app-header'),
+  });
+</script>
+
 <div class="settings-card fade-in" id="settingsCard">
   <div class="loading-state" id="loadingState">
     <div class="loading-spinner"></div>
@@ -1032,7 +1009,7 @@ function render() {
   const tier1 = features.filter(f => f.tier === 1);
   const tier2 = features.filter(f => f.tier === 2);
 
-  card.innerHTML = renderHeader()
+  card.innerHTML = ''
     + renderConfigSection(config)
     + '<hr class="section-divider">'
     + renderProviders()
@@ -1053,23 +1030,6 @@ function render() {
     + renderFooter();
 
   bindEvents();
-}
-
-/* ------------------------------------------------------------------ */
-/*  Header                                                             */
-/* ------------------------------------------------------------------ */
-function renderHeader() {
-  return '<div class="wordmark-wrapper">'
-    + '<h1 class="wordmark wordmark-sm">amplifier</h1>'
-    + '<p style="color: var(--ink-slate); font-size: 1.1rem; margin-top: 8px;">Settings</p>'
-    + '</div>'
-    + '<div class="header" style="margin-top: 24px; margin-bottom: 0;">'
-    + '<div></div>'
-    + '<div class="header-actions">'
-    + '<a href="/">Back to Dashboard</a>'
-    + '<span id="feedback-slot"></span>'
-    + '</div>'
-    + '</div>';
 }
 
 /* ------------------------------------------------------------------ */
@@ -1535,14 +1495,6 @@ function esc(str) {
 /*  Boot                                                               */
 /* ================================================================== */
 loadAll();
-</script>
-<script src="/static/feedback-widget.js"></script>
-<script>
-  AmplifierFeedback.init({
-    mode: 'inline',
-    container: document.getElementById('feedback-slot'),
-    context: { app: 'settings' },
-  });
 </script>
 </body>
 </html>

--- a/distro-server/src/amplifier_distro/server/apps/slack/static/slack-setup.html
+++ b/distro-server/src/amplifier_distro/server/apps/slack/static/slack-setup.html
@@ -7,6 +7,8 @@
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <script src="/static/theme-init.js"></script>
 <link rel="stylesheet" href="/static/amplifier-theme.css">
+<script src="/static/feedback-widget.js"></script>
+<script src="/static/amplifier-header.js"></script>
 <style>
 /* ------------------------------------------------------------------ */
 /*  Page-specific tokens                                               */
@@ -31,8 +33,8 @@ html, body {
 
 body {
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: center;
   min-height: 100vh;
   padding: 40px 20px;
 }
@@ -299,28 +301,19 @@ body {
   font-size: 13px;
 }
 
-/* ------------------------------------------------------------------ */
-/*  Footer                                                             */
-/* ------------------------------------------------------------------ */
-.footer {
-  margin-top: 24px;
-  text-align: center;
-  font-size: 13px;
-  color: var(--ink-slate);
-}
-
-.footer a {
-  color: var(--signal);
-  text-decoration: none;
-}
-
-.footer a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>
+<div id="app-header" style="width:100%;max-width:640px;"></div>
+<script>
+AmplifierHeader.init({
+  appName: 'slack',
+  backLink: { url: '/apps/settings/', label: 'Settings' },
+  feedbackApp: 'slack-setup',
+  container: document.getElementById('app-header'),
+});
+</script>
 <div class="card">
-  <h1 class="wordmark wordmark-sm">amplifier</h1>
-  <p style="color: var(--ink-slate); font-size: 1.1rem; margin-top: 8px; text-align: center;">Connect Slack</p>
   <p class="tagline">Bridge your Slack workspace to Amplifier</p>
 
   <!-- ============================================================ -->
@@ -418,9 +411,6 @@ body {
     </div>
   </div>
 
-  <div class="footer">
-    <a href="/apps/settings/">Back to settings</a>
-  </div>
 </div>
 
 <script>

--- a/distro-server/src/amplifier_distro/server/apps/voice/static/index.html
+++ b/distro-server/src/amplifier_distro/server/apps/voice/static/index.html
@@ -8,6 +8,7 @@
 <script src="/apps/voice/static/connection-health.mjs"></script>
 <script src="/static/theme-init.js"></script>
 <script src="/static/feedback-widget.js"></script>
+<script src="/static/amplifier-header.js"></script>
 
 <link rel="stylesheet" href="/static/amplifier-theme.css">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
@@ -36,21 +37,15 @@ body {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Header                                                             */
+/*  Status bar (replaces old .app-header; wordmark moved to shared    */
+/*  AmplifierHeader above the #app mount point)                       */
 /* ------------------------------------------------------------------ */
-.app-header {
+.app-status-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px 0;
-  border-bottom: 1px solid var(--canvas-mist);
-}
-
-.app-title {
-  font-family: var(--font-heading);
-  font-size: clamp(1.5rem, 4vw, 2.2rem);
-  color: var(--signal);
-  letter-spacing: 0.05em;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 0;
 }
 
 /* ------------------------------------------------------------------ */
@@ -698,6 +693,15 @@ body {
 </style>
 </head>
 <body>
+<div id="app-header" style="width:100%;max-width:900px;margin:0 auto;"></div>
+<script>
+AmplifierHeader.init({
+  appName: 'voice',
+  backLink: { url: '/', label: 'Dashboard' },
+  feedbackApp: 'voice',
+  container: document.getElementById('app-header'),
+});
+</script>
 <div id="app"></div>
 
 <script>
@@ -1864,7 +1868,6 @@ body {
     const [isConnecting, setIsConnecting] = useState(false);
     const [sessionId, setSessionId] = useState(null);  // Task 5.3: session state
     const transcriptEndRef = useRef(null);
-    const feedbackSlotRef = useRef(null);
 
     // Task 5.5: connection health manager (stable across renders)
     const healthManagerRef = useRef(null);
@@ -1987,19 +1990,7 @@ body {
     // Wire latest handler into stable ref on every render (ref mutation, no rerender)
     msgHandlerRef.current = handleDataChannelEvent;
 
-    // Mount shared feedback widget into header slot (once)
-    useEffect(() => {
-      const slot = feedbackSlotRef.current;
-      if (!slot || slot.childElementCount > 0) return;
-      if (window.AmplifierFeedback) {
-        window.AmplifierFeedback.init({
-          mode: 'inline',
-          container: slot,
-          label: 'Feedback',
-          context: { app: 'voice' },
-        });
-      }
-    }, []);
+    // Feedback widget is now handled by AmplifierHeader above the #app mount point.
 
     // delegation-feedback: SSE consumer with delegation lifecycle
     const { delegationState } = useAmplifierEvents({
@@ -2192,15 +2183,11 @@ body {
 
     return html`
       <div id="app">
-        <div class="app-header">
-          <h1 class="wordmark wordmark-sm">amplifier voice</h1>
-          <div style="display:flex;align-items:center;gap:8px;">
-            ${muted && html`<span class="muted-badge">🎙 Muted</span>`}
-            <div class=${'status-badge ' + rtcState}>
-              <div class="status-dot"></div>
-              ${statusLabel}
-            </div>
-            <span ref=${feedbackSlotRef} style="font-size:13px;"></span>
+        <div class="app-status-bar">
+          ${muted && html`<span class="muted-badge">🎙 Muted</span>`}
+          <div class=${'status-badge ' + rtcState}>
+            <div class="status-dot"></div>
+            ${statusLabel}
           </div>
         </div>
 

--- a/distro-server/src/amplifier_distro/server/static/amplifier-header.js
+++ b/distro-server/src/amplifier_distro/server/static/amplifier-header.js
@@ -1,0 +1,343 @@
+/**
+ * Amplifier Shared Header
+ *
+ * Renders a consistent app header with wordmark, navigation, feedback slot,
+ * and optional auth controls (username + logout).
+ *
+ * Usage:
+ *   AmplifierHeader.init({
+ *     appName: 'settings',           // shown after "amplifier" in wordmark
+ *     backLink: { url: '/', label: 'Dashboard' },  // optional
+ *     feedbackApp: 'settings',       // optional, enables feedback widget
+ *     container: document.getElementById('app-header'),  // required
+ *   });
+ */
+(function () {
+  'use strict';
+
+  /* ------------------------------------------------------------------ */
+  /*  Stylesheet (injected once)                                         */
+  /* ------------------------------------------------------------------ */
+
+  var CSS = [
+    '.amp-header {',
+    '  display: flex;',
+    '  align-items: center;',
+    '  justify-content: space-between;',
+    '  padding: 16px 0;',
+    '  border-bottom: 1px solid var(--canvas-mist);',
+    '  margin-bottom: 24px;',
+    '  animation: fadeIn var(--duration-fast, 200ms) var(--ease-out, ease);',
+    '}',
+
+    '.amp-header-left {',
+    '  display: flex;',
+    '  align-items: center;',
+    '  gap: 8px;',
+    '  min-width: 0;',
+    '}',
+
+    '.amp-header-wordmark {',
+    '  font-family: var(--font-heading, "Syne", system-ui, sans-serif);',
+    '  font-weight: 700;',
+    '  font-size: clamp(1.25rem, 4vw, 1.75rem);',
+    '  color: var(--signal, #5B4DE3);',
+    '  letter-spacing: -0.03em;',
+    '  text-transform: lowercase;',
+    '  text-decoration: none;',
+    '  transition: color var(--duration-fast, 200ms) var(--ease-out, ease);',
+    '  white-space: nowrap;',
+    '}',
+
+    '.amp-header-wordmark:hover {',
+    '  color: var(--signal-light, #7B6FF0);',
+    '}',
+
+    '.amp-header-app-name {',
+    '  color: var(--ink-slate, #5C5C5C);',
+    '  font-weight: 600;',
+    '}',
+
+    '.amp-header-right {',
+    '  display: flex;',
+    '  align-items: center;',
+    '  gap: 12px;',
+    '  flex-shrink: 1;',
+    '  flex-wrap: wrap;',
+    '  justify-content: flex-end;',
+    '}',
+
+    '.amp-header-nav-link {',
+    '  font-size: 14px;',
+    '  font-weight: 600;',
+    '  color: var(--signal, #5B4DE3);',
+    '  text-decoration: none;',
+    '  padding: 6px 14px;',
+    '  border: 1px solid var(--signal, #5B4DE3);',
+    '  border-radius: var(--radius-button, 14px);',
+    '  transition: all var(--duration-fast, 200ms) var(--ease-out, ease);',
+    '  white-space: nowrap;',
+    '}',
+
+    '.amp-header-nav-link:hover {',
+    '  background: var(--signal, #5B4DE3);',
+    '  color: #fff;',
+    '}',
+
+    '.amp-header-user {',
+    '  display: flex;',
+    '  align-items: center;',
+    '  gap: 8px;',
+    '  padding-left: 12px;',
+    '  border-left: 1px solid var(--canvas-mist, #EEEAE5);',
+    '}',
+
+    '.amp-header-username {',
+    '  font-size: 13px;',
+    '  color: var(--ink-slate, #5C5C5C);',
+    '  font-weight: 500;',
+    '}',
+
+    '.amp-header-logout {',
+    '  font-size: 13px;',
+    '  font-weight: 600;',
+    '  color: var(--ink-fog, #7A7A7A);',
+    '  background: none;',
+    '  border: 1px solid var(--canvas-mist, #EEEAE5);',
+    '  border-radius: var(--radius-button, 14px);',
+    '  padding: 4px 12px;',
+    '  cursor: pointer;',
+    '  font-family: var(--font-body, "Epilogue", system-ui, sans-serif);',
+    '  transition: all var(--duration-fast, 200ms) var(--ease-out, ease);',
+    '}',
+
+    '.amp-header-logout:hover {',
+    '  color: var(--error, #C53030);',
+    '  border-color: var(--error, #C53030);',
+    '}',
+
+    '@media (max-width: 480px) {',
+    '  .amp-header {',
+    '    flex-direction: column;',
+    '    align-items: flex-start;',
+    '    gap: 12px;',
+    '  }',
+    '  .amp-header-right {',
+    '    width: 100%;',
+    '    flex-wrap: wrap;',
+    '  }',
+    '}',
+  ].join('\n');
+
+  /* ------------------------------------------------------------------ */
+  /*  Helpers                                                            */
+  /* ------------------------------------------------------------------ */
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === 'className') {
+          node.className = attrs[k];
+        } else if (k.slice(0, 2) === 'on') {
+          node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+        } else {
+          node.setAttribute(k, attrs[k]);
+        }
+      });
+    }
+    (children || []).forEach(function (c) {
+      if (typeof c === 'string') {
+        node.appendChild(document.createTextNode(c));
+      } else if (c) {
+        node.appendChild(c);
+      }
+    });
+    return node;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Style injection                                                    */
+  /* ------------------------------------------------------------------ */
+
+  var styleInjected = false;
+
+  function injectStyle() {
+    if (styleInjected) return;
+    var s = document.createElement('style');
+    s.textContent = CSS;
+    document.head.appendChild(s);
+    styleInjected = true;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Auth detection                                                     */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Fetch /auth/me to determine auth state.
+   * Returns a promise resolving to:
+   *   { authEnabled: false }                — 404 means local/no-auth mode
+   *   { authEnabled: true, username: str }  — 200 with a logged-in user
+   *   { authEnabled: true, username: null } — 401 or other error
+   */
+  function detectAuth() {
+    return fetch('/auth/me', { credentials: 'same-origin' })
+      .then(function (res) {
+        if (res.status === 404) {
+          return { authEnabled: false, username: null };
+        }
+        if (res.status === 200) {
+          return res.json().then(function (data) {
+            return { authEnabled: true, username: data.username || null };
+          });
+        }
+        // 401, 403, or any other status — auth is present but no active session
+        return { authEnabled: true, username: null };
+      })
+      .catch(function () {
+        // Network failure — assume local mode (fail safe: don't show logout)
+        return { authEnabled: false, username: null };
+      });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Logout handler                                                     */
+  /* ------------------------------------------------------------------ */
+
+  function doLogout() {
+    fetch('/logout', { method: 'POST', redirect: 'follow', credentials: 'same-origin' })
+      .then(function () {
+        window.location.href = '/login';
+      })
+      .catch(function () {
+        window.location.href = '/login';
+      });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Header builder                                                     */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Build and inject the header DOM into opts.container, then init
+   * the feedback widget if requested.
+   *
+   * @param {Object}      opts
+   * @param {HTMLElement} opts.container    — mount target (required)
+   * @param {string}      [opts.appName]   — subtitle shown after "amplifier"
+   * @param {Object}      [opts.backLink]  — { url, label } for nav link
+   * @param {string}      [opts.feedbackApp] — enables feedback widget inline
+   * @param {Object}      authResult       — { authEnabled, username }
+   * @returns {{ headerEl, feedbackSlot }}
+   */
+  function buildHeader(opts, authResult) {
+    var container = opts.container;
+
+    /* --- Left: wordmark --- */
+    var wordmarkChildren = ['amplifier'];
+    if (opts.appName) {
+      wordmarkChildren.push(
+        el('span', { className: 'amp-header-app-name' }, [' ' + opts.appName])
+      );
+    }
+    var wordmarkEl = el(
+      'a',
+      { className: 'amp-header-wordmark', href: '/' },
+      wordmarkChildren
+    );
+
+    var leftEl = el('div', { className: 'amp-header-left' }, [wordmarkEl]);
+
+    /* --- Right: nav link + feedback slot + user --- */
+    var rightChildren = [];
+
+    if (opts.backLink && opts.backLink.url) {
+      rightChildren.push(
+        el(
+          'a',
+          { className: 'amp-header-nav-link', href: opts.backLink.url },
+          [opts.backLink.label || 'Back']
+        )
+      );
+    }
+
+    var feedbackSlotEl = null;
+    if (opts.feedbackApp) {
+      feedbackSlotEl = el('span', { className: 'amp-header-feedback-slot' });
+      rightChildren.push(feedbackSlotEl);
+    }
+
+    if (authResult.authEnabled && authResult.username) {
+      var usernameEl = el(
+        'span',
+        { className: 'amp-header-username' },
+        [authResult.username]
+      );
+      var logoutBtn = el(
+        'button',
+        { className: 'amp-header-logout', type: 'button', onClick: doLogout },
+        ['Sign out']
+      );
+      var userEl = el('div', { className: 'amp-header-user' }, [usernameEl, logoutBtn]);
+      rightChildren.push(userEl);
+    }
+
+    var rightEl = el('div', { className: 'amp-header-right' }, rightChildren);
+
+    /* --- Assemble header --- */
+    var headerEl = el('header', { className: 'amp-header' }, [leftEl, rightEl]);
+
+    /* Clear container and inject */
+    container.innerHTML = '';
+    container.appendChild(headerEl);
+
+    /* --- Init feedback widget if requested --- */
+    if (feedbackSlotEl && opts.feedbackApp) {
+      if (window.AmplifierFeedback) {
+        window.AmplifierFeedback.init({
+          mode: 'inline',
+          container: feedbackSlotEl,
+          context: { app: opts.feedbackApp },
+        });
+      }
+    }
+
+    return { headerEl: headerEl, feedbackSlot: feedbackSlotEl };
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Public API                                                         */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Initialise the shared header.
+   *
+   * @param {Object}      opts
+   * @param {HTMLElement} opts.container    — mount target (required)
+   * @param {string}      [opts.appName]   — page subtitle, e.g. 'settings'
+   * @param {Object}      [opts.backLink]  — { url: '/', label: 'Dashboard' }
+   * @param {string}      [opts.feedbackApp] — enables inline feedback widget
+   * @returns {Promise<{ headerEl, feedbackSlot }>}
+   */
+  function init(opts) {
+    opts = opts || {};
+
+    if (!opts.container) {
+      console.warn('[AmplifierHeader] opts.container is required');
+      return Promise.resolve({ headerEl: null, feedbackSlot: null });
+    }
+
+    injectStyle();
+
+    return detectAuth().then(function (authResult) {
+      return buildHeader(opts, authResult);
+    });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Export                                                             */
+  /* ------------------------------------------------------------------ */
+
+  window.AmplifierHeader = { init: init };
+})();

--- a/distro-server/src/amplifier_distro/server/static/index.html
+++ b/distro-server/src/amplifier_distro/server/static/index.html
@@ -18,6 +18,8 @@
 <body>
 
 <div class="container">
+  <div id="app-header"></div>
+
   <!-- Wordmark -->
   <div class="wordmark-wrapper">
     <h1 class="wordmark">amplifier</h1>
@@ -62,17 +64,16 @@
     <a href="/apps/install-wizard/">Setup wizard</a> &middot;
     <a href="/api/apps">API</a> &middot;
     <a href="/api/docs">Swagger UI</a> &middot;
-    <a href="/api/openapi.json">OpenAPI spec</a> &middot;
-    <span id="feedback-slot"></span>
+    <a href="/api/openapi.json">OpenAPI spec</a>
   </div>
 </div>
 
 <script src="/static/feedback-widget.js"></script>
+<script src="/static/amplifier-header.js"></script>
 <script>
-  AmplifierFeedback.init({
-    mode: 'inline',
-    container: document.getElementById('feedback-slot'),
-    context: { app: 'dashboard' },
+  AmplifierHeader.init({
+    container: document.getElementById('app-header'),
+    feedbackApp: 'dashboard',
   });
 </script>
 </body>


### PR DESCRIPTION
Addresses microsoft/amplifier-distro#86 and microsoft/amplifier-distro#136

## Summary

Creates a shared header component (`amplifier-header.js`) and integrates it across the dashboard, settings, voice, and slack-setup apps. The header provides consistent navigation, branding, and auth-aware user/logout controls.

## What's new

- **`amplifier-header.js`** — Self-contained vanilla JS component (IIFE pattern, like `feedback-widget.js`) that renders a consistent header bar
- **Auth-aware logout** — Fetches `GET /auth/me` to detect auth state. When auth is active, shows username + "Sign out" button. In local mode (no auth/TLS), the user section is hidden entirely
- **Consistent navigation** — Every sub-app now has a back-link to its parent (Dashboard or Settings)

## Per-app changes

| App | Changes |
|-----|---------|
| **Dashboard** | Added shared header (user/logout when auth active). Hero wordmark preserved as page identity. Feedback widget moved from footer to header. |
| **Settings** | Replaced ad-hoc `renderHeader()` with shared header. Removed ~30 lines of orphaned header CSS. |
| **Voice** | Shared header placed outside Preact mount. Old `.app-header` simplified to status-bar (connection badges only). Added missing "Back to Dashboard" nav. |
| **Slack Setup** | Added header above wizard card. Removed duplicate wordmark from card. Added feedback widget (was previously missing). Removed redundant footer back-link. |
| **Chat** | Not touched — other changes in flight |

## Auth behavior

| Condition | Header shows |
|-----------|-------------|
| Auth disabled (local mode, no TLS) | Wordmark + nav + feedback only |
| Auth enabled, user authenticated | + username + "Sign out" button |
| Auth enabled, no session | + hidden user section (middleware redirects to /login) |