### PR TITLE
feat(slack): add progress indicator, file download, and prompt enrichment

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/slack/client.py
+++ b/distro-server/src/amplifier_distro/server/apps/slack/client.py
@@ -57,6 +57,20 @@ class SlackClient(Protocol):
         """Get the bot's own user ID."""
         ...
 
+    async def upload_file(
+        self,
+        channel: str,
+        thread_ts: str | None = None,
+        filepath: str = "",
+        title: str = "",
+    ) -> None:
+        """Upload a file to a channel/thread."""
+        ...
+
+    async def delete_message(self, channel: str, ts: str) -> None:
+        """Delete a message."""
+        ...
+
 
 @dataclass
 class SentMessage:
@@ -138,6 +152,26 @@ class MemorySlackClient:
 
     async def get_bot_user_id(self) -> str:
         return self.bot_user_id
+
+    async def upload_file(
+        self,
+        channel: str,
+        thread_ts: str | None = None,
+        filepath: str = "",
+        title: str = "",
+    ) -> None:
+        self.sent_messages.append(
+            SentMessage(
+                channel=channel,
+                text=f"[file upload: {title or filepath}]",
+                thread_ts=thread_ts,
+                blocks=None,
+                ts=self._next_ts(),
+            )
+        )
+
+    async def delete_message(self, channel: str, ts: str) -> None:
+        pass  # No-op for testing
 
 
 class HttpSlackClient:
@@ -227,3 +261,37 @@ class HttpSlackClient:
             self._bot_user_id = result["user_id"]
         assert self._bot_user_id is not None
         return self._bot_user_id
+
+    async def upload_file(
+        self,
+        channel: str,
+        thread_ts: str | None = None,
+        filepath: str = "",
+        title: str = "",
+    ) -> None:
+        """Upload a file to Slack via files.upload (v1 API)."""
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            with open(filepath, "rb") as f:
+                data = {
+                    "channels": channel,
+                    "title": title or filepath,
+                }
+                if thread_ts:
+                    data["thread_ts"] = thread_ts
+                response = await client.post(
+                    f"{self._base_url}/files.upload",
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    data=data,
+                    files={"file": (title or "file", f)},
+                )
+                result = response.json()
+                if not result.get("ok"):
+                    raise RuntimeError(
+                        f"Slack file upload error: {result.get('error', 'unknown')}"
+                    )
+
+    async def delete_message(self, channel: str, ts: str) -> None:
+        """Delete a message from a channel."""
+        await self._api_call("chat.delete", channel=channel, ts=ts)

--- a/distro-server/src/amplifier_distro/server/apps/slack/events.py
+++ b/distro-server/src/amplifier_distro/server/apps/slack/events.py
@@ -11,10 +11,13 @@ Security:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import logging
+import re as _re
 import time
+from pathlib import Path
 from typing import Any
 
 from .client import SlackClient
@@ -23,6 +26,31 @@ from .config import SlackConfig
 from .formatter import SlackFormatter
 from .models import SlackMessage
 from .sessions import SlackSessionManager
+
+# Friendly names for tool operations shown in progress messages
+TOOL_FRIENDLY_NAMES: dict[str, str] = {
+    "read_file": "Reading files",
+    "write_file": "Writing files",
+    "edit_file": "Editing files",
+    "apply_patch": "Applying patches",
+    "bash": "Running command",
+    "grep": "Searching",
+    "glob": "Finding files",
+    "delegate": "Delegating to agent",
+    "web_search": "Searching the web",
+    "web_fetch": "Fetching web content",
+    "python_check": "Checking code quality",
+    "LSP": "Analyzing code",
+    "todo": "Planning tasks",
+    "recipes": "Running recipe",
+    "mode": "Switching mode",
+}
+
+# Max file size for downloads (50 MB)
+_MAX_FILE_SIZE = 50 * 1024 * 1024
+
+# Progress message update throttle
+_STATUS_THROTTLE_SECS = 2.0
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +206,7 @@ class SlackEventHandler:
         # Check if there's a session mapping for this context
         mapping = self._sessions.get_mapping(channel_id, thread_ts)
         if mapping and mapping.is_active:
-            await self._handle_session_message(message)
+            await self._handle_session_message(message, event=event)
             return
 
         # No active session mapping for this context
@@ -402,13 +430,298 @@ class SlackEventHandler:
                     parts.append(text)
         return "\n".join(parts)
 
-    async def _handle_session_message(self, message: SlackMessage) -> None:
+    # --- Prompt enrichment (Task 1) ---
+
+    async def _build_prompt(
+        self,
+        message: SlackMessage,
+        file_descriptions: list[str] | None = None,
+    ) -> str:
+        """Build an enriched prompt with context metadata.
+
+        Wraps the user's raw text with sender/channel info and any
+        uploaded file descriptions so the AI has full context.
+        """
+        parts: list[str] = []
+
+        # Sender and channel context
+        channel_info = await self._client.get_channel_info(message.channel_id)
+        channel_label = f"#{channel_info.name}" if channel_info else message.channel_id
+        parts.append(f"[From <@{message.user_id}> in {channel_label}]")
+
+        # File descriptions (populated by _download_files)
+        if file_descriptions:
+            parts.append("[User uploaded files:")
+            parts.extend(f"  {desc}" for desc in file_descriptions)
+            parts.append("]")
+
+        # The actual user message
+        parts.append(message.text)
+
+        return "\n".join(parts)
+
+    # --- File download (Task 2) ---
+
+    async def _download_files(
+        self,
+        event: dict[str, Any],
+        working_dir: str,
+        channel_id: str = "",
+        thread_ts: str = "",
+    ) -> list[str]:
+        """Download files attached to a Slack message.
+
+        Returns a list of description strings like:
+            "report.py (1234 bytes) -> ./report.py"
+
+        On failure, posts an error message to the Slack thread so
+        the user knows what went wrong.
+        """
+        files = event.get("files", [])
+        if not files:
+            return []
+
+        descriptions: list[str] = []
+        errors: list[str] = []
+        wd = Path(working_dir).expanduser()
+        wd.mkdir(parents=True, exist_ok=True)
+
+        for file_info in files:
+            url = file_info.get("url_private")
+            name = file_info.get("name", "file")
+            size = file_info.get("size", 0)
+
+            if not url:
+                errors.append(f"{name}: no download URL available")
+                continue
+
+            # Enforce size limit
+            if size > _MAX_FILE_SIZE:
+                errors.append(f"{name}: file too large ({size:,} bytes, max 50MB)")
+                logger.warning("File %s too large (%d bytes), skipping", name, size)
+                continue
+
+            # Sanitize filename
+            safe_name = _re.sub(r"[^\w\-.]", "_", name)
+
+            # Handle filename conflicts
+            dest = wd / safe_name
+            counter = 1
+            while dest.exists():
+                stem = Path(safe_name).stem
+                suffix = Path(safe_name).suffix
+                dest = wd / f"{stem}_{counter}{suffix}"
+                counter += 1
+
+            # Download
+            try:
+                import aiohttp  # pyright: ignore[reportMissingImports]
+
+                async with aiohttp.ClientSession() as session:
+                    headers = {"Authorization": f"Bearer {self._config.bot_token}"}
+                    async with session.get(url, headers=headers) as resp:
+                        if resp.status == 200:
+                            data = await resp.read()
+                            # Detect HTML redirect (missing files:read scope)
+                            content_type = resp.headers.get("Content-Type", "")
+                            if "text/html" in content_type or (
+                                len(data) < 10000
+                                and data[:15].lower().startswith(b"<!doctype html")
+                            ):
+                                errors.append(
+                                    f"{name}: got HTML instead of file content "
+                                    "(Slack app needs `files:read` scope -- "
+                                    "reinstall the app with updated permissions)"
+                                )
+                                logger.warning(
+                                    "File %s returned HTML instead of content. "
+                                    "Add files:read scope and reinstall.",
+                                    name,
+                                )
+                                continue
+                            dest.write_bytes(data)
+                            descriptions.append(
+                                f"{name} ({size} bytes) -> ./{dest.name}"
+                            )
+                            logger.info("Downloaded %s -> %s", name, dest)
+                        elif resp.status == 403:
+                            errors.append(
+                                f"{name}: access denied (HTTP 403). "
+                                "Slack app needs `files:read` scope."
+                            )
+                            logger.warning(
+                                "File download 403 for %s -- missing files:read scope",
+                                name,
+                            )
+                        else:
+                            errors.append(
+                                f"{name}: download failed (HTTP {resp.status})"
+                            )
+                            logger.warning(
+                                "Failed to download %s: HTTP %d", name, resp.status
+                            )
+            except ImportError:
+                errors.append(
+                    "File downloads require aiohttp. "
+                    "Install with: `uv pip install amplifier-distro[slack]`"
+                )
+                logger.warning("aiohttp not available for file downloads")
+                break
+            except Exception:
+                errors.append(f"{name}: download failed (unexpected error)")
+                logger.exception("Error downloading file %s", name)
+
+        # Post errors to the Slack thread so the user sees them
+        if errors and channel_id:
+            error_text = ":warning: *File download issues:*\n" + "\n".join(
+                f"\u2022 {e}" for e in errors
+            )
+            try:
+                await self._client.post_message(
+                    channel_id, text=error_text, thread_ts=thread_ts or None
+                )
+            except Exception:
+                logger.debug("Failed to post file error to Slack", exc_info=True)
+
+        return descriptions
+
+    # --- Progress messages (Tasks 4-6) ---
+
+    def _friendly_tool_name(self, tool_name: str) -> str:
+        """Map internal tool names to user-friendly labels."""
+        return TOOL_FRIENDLY_NAMES.get(tool_name, tool_name.replace("_", " ").title())
+
+    @staticmethod
+    def _render_todo_status(todos: list[dict[str, Any]]) -> str:
+        """Render a todo list as a compact progress display.
+
+        Shows completed count, current in-progress item, next few
+        pending items, and a +N more indicator.
+        """
+        completed = [t for t in todos if t.get("status") == "completed"]
+        in_progress = [t for t in todos if t.get("status") == "in_progress"]
+        pending = [t for t in todos if t.get("status") == "pending"]
+
+        lines: list[str] = []
+
+        # Completed summary
+        if completed:
+            lines.append(f"\u2705  {len(completed)} completed")
+
+        # In-progress (show all, usually just one)
+        for t in in_progress:
+            content = t.get("activeForm") or t.get("content", "Working")
+            lines.append(f"\u25b8  *{content}*")
+
+        # Pending (show next 2, then +N more)
+        shown_pending = pending[:2]
+        for t in shown_pending:
+            content = t.get("content", "")
+            lines.append(f"\u25cb  {content}")
+
+        remaining = len(pending) - len(shown_pending)
+        if remaining > 0:
+            lines.append(f"   +{remaining} more")
+
+        return "\n".join(lines)
+
+    async def _execute_with_progress(
+        self,
+        message: SlackMessage,
+        enriched_text: str,
+    ) -> str | None:
+        """Execute a session message with a live progress indicator.
+
+        Posts an editable "Working..." status message, runs the prompt
+        via send_message() (which blocks until complete), updates the
+        status with elapsed time while waiting, then deletes the status
+        message and returns the response.
+        """
+        mapping = self._sessions.get_mapping(message.channel_id, message.thread_ts)
+        if mapping is None or not mapping.is_active:
+            return None
+
+        reply_thread = message.thread_ts or message.ts
+
+        # Post initial status message
+        status_ts = await self._client.post_message(
+            message.channel_id,
+            text="\u2699\ufe0f Working...",
+            thread_ts=reply_thread,
+        )
+
+        start_time = time.monotonic()
+
+        async def _update_status_loop() -> None:
+            """Periodically update the status message with elapsed time."""
+            while True:
+                await asyncio.sleep(_STATUS_THROTTLE_SECS)
+                elapsed = time.monotonic() - start_time
+                if elapsed < 10:
+                    continue  # Don't show elapsed for quick responses
+                minutes = int(elapsed) // 60
+                seconds = int(elapsed) % 60
+                elapsed_str = (
+                    f"{minutes}m {seconds:02d}s" if minutes else f"{seconds}s"
+                )
+                try:
+                    await self._client.update_message(
+                        message.channel_id,
+                        status_ts,
+                        text=f"\u2699\ufe0f Working... \u00b7 {elapsed_str}",
+                    )
+                except Exception:
+                    logger.debug("Failed to update status message", exc_info=True)
+
+        # Run the execution and status updater concurrently
+        status_task = asyncio.create_task(_update_status_loop())
+        try:
+            response = await self._sessions.route_message(
+                message, text_override=enriched_text
+            )
+        except Exception:
+            logger.exception("Error during session execution")
+            response = "Error: Failed to get response from Amplifier session."
+        finally:
+            status_task.cancel()
+
+        # Delete the status message
+        try:
+            await self._client.delete_message(message.channel_id, status_ts)
+        except Exception:
+            logger.debug("Failed to delete status message", exc_info=True)
+
+        return response
+
+    # --- Session message handler (rewritten) ---
+
+    async def _handle_session_message(
+        self,
+        message: SlackMessage,
+        event: dict[str, Any] | None = None,
+    ) -> None:
         """Route a message to its mapped Amplifier session."""
         # Add thinking indicator (best-effort)
         await self._safe_react(message.channel_id, message.ts, "hourglass_flowing_sand")
 
-        # Route through session manager
-        response = await self._sessions.route_message(message)
+        # Look up the session mapping for file download and outbox
+        mapping = self._sessions.get_mapping(message.channel_id, message.thread_ts)
+
+        # Download attached files if present
+        file_descriptions: list[str] | None = None
+        if event and event.get("files") and mapping and mapping.working_dir:
+            file_descriptions = await self._download_files(
+                event,
+                mapping.working_dir,
+                channel_id=message.channel_id,
+                thread_ts=message.thread_ts or message.ts,
+            )
+
+        # Build enriched prompt with context
+        enriched_text = await self._build_prompt(message, file_descriptions)
+
+        # Execute with live progress updates
+        response = await self._execute_with_progress(message, enriched_text)
 
         if response:
             reply_thread = message.thread_ts or message.ts

--- a/distro-server/src/amplifier_distro/server/apps/slack/sessions.py
+++ b/distro-server/src/amplifier_distro/server/apps/slack/sessions.py
@@ -273,11 +273,18 @@ class SlackSessionManager:
         )
         return mapping
 
-    async def route_message(self, message: SlackMessage) -> str | None:
+    async def route_message(
+        self, message: SlackMessage, text_override: str | None = None
+    ) -> str | None:
         """Route a Slack message to the appropriate Amplifier session.
 
         Returns the response text, or None if no session is mapped.
         Updates the last_active timestamp on the mapping.
+
+        Args:
+            message: The Slack message to route.
+            text_override: If provided, send this text instead of message.text.
+                Used for enriched prompts with context metadata.
         """
         mapping = self.get_mapping(message.channel_id, message.thread_ts)
         if mapping is None or not mapping.is_active:
@@ -287,10 +294,11 @@ class SlackSessionManager:
         mapping.last_active = datetime.now(UTC).isoformat()
         self._save_sessions()
 
-        # Send to backend
+        # Send to backend (use enriched text if provided)
+        prompt = text_override if text_override is not None else message.text
         try:
             response = await self._backend.send_message(
-                mapping.session_id, message.text
+                mapping.session_id, prompt
             )
             return response
         except ValueError:

--- a/distro-server/src/amplifier_distro/server/apps/slack/setup.py
+++ b/distro-server/src/amplifier_distro/server/apps/slack/setup.py
@@ -62,6 +62,8 @@ SLACK_APP_MANIFEST = {
                 "reactions:write",
                 "channels:manage",
                 "channels:join",
+                "files:read",
+                "files:write",
             ],
         },
     },

--- a/distro-server/uv.lock
+++ b/distro-server/uv.lock
@@ -178,6 +178,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "python-pam" },
     { name = "pyyaml" },
+    { name = "six" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "uvicorn", extra = ["standard"] },
@@ -205,6 +206,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "python-pam", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "six" },
     { name = "slack-bolt", specifier = ">=1.18.0" },
     { name = "slack-sdk", specifier = ">=3.26.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.20.0" },
@@ -981,6 +983,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Improves the Slack bridge UX with three features that make the experience go from "silence during execution" to "informed and interactive."

## Changes

### Progress Indicator
- Posts an editable "\u2699\ufe0f Working..." status message in the thread during execution
- Updates with elapsed time after 10 seconds ("\u2699\ufe0f Working... \u00b7 25s")
- Auto-deletes when the response arrives — no clutter left behind

### File Download (user \u2192 AI)
- Users can drop files into a session thread
- Files downloaded to the session's working directory (50MB limit, filename sanitization, conflict resolution)
- File descriptions added to the prompt so the AI knows what was uploaded
- **Error visibility**: if download fails (e.g., missing `files:read` scope), a warning message appears in the thread with actionable fix instructions

### Prompt Enrichment
- Every message to the AI is now wrapped with context:
  `[From <@user_id> in #channel-name]`
- AI can address users by name and give channel-aware responses

### Manifest & Client Updates
- Added `files:read` and `files:write` to bot scopes in the app manifest
- Added `upload_file()` and `delete_message()` to `SlackClient` protocol + both implementations

## What's NOT in this PR
- `.outbox/` auto-upload (removed due to risk of accidental sensitive file exposure — needs a safer design)
- Rich tool-level progress ("Reading files...", "Delegating to agent...") — requires event-queue wiring, deferred to follow-up
- Todo/plan rendering in progress messages — same dependency, deferred

## Testing
- 157 existing tests pass, 0 failures
- Manually validated: progress indicator, file download with `files:read` scope, error messages on scope failure

## Files Changed
| File | Change |
|------|--------|
| `events.py` | `_build_prompt`, `_download_files`, `_execute_with_progress`, progress helpers |
| `sessions.py` | `text_override` param on `route_message()` |
| `client.py` | `upload_file()` + `delete_message()` on protocol + implementations |
| `setup.py` | `files:read`, `files:write` added to bot scopes |