### PR TITLE
fix(e2e-browser-tests): add https support, CDP browser_setup, and increase timeout

### DIFF
--- a/.amplifier/recipes/e2e-browser-tests.yaml
+++ b/.amplifier/recipes/e2e-browser-tests.yaml
@@ -25,7 +25,7 @@ tags:
 # Context — defaults; override at execution time if needed
 # ---------------------------------------------------------------------------
 context:
-  server_url: "http://127.0.0.1:8400"  # Supports both http:// and https://
+  server_url: "http://127.0.0.1:28400"  # Supports both http:// and https://
   slack_workspace: "https://amplifiercrew.slack.com/"
   slack_channel: "amplifier"
   browser_setup: ""  # Optional context for browser setup (e.g., CDP connection, RDP config)


### PR DESCRIPTION
## E2E Browser Test Recipe v2.0.0

Major restructure for reliability, automation, and CI readiness.

### Breaking Changes
- **S01-S16 split into 3 steps**: `chat-e2e-core` (S01-05), `chat-e2e-sessions` (S06-11), `chat-e2e-commands` (S12-16). Better timeout management and granular failure reporting.
- **S18-S25 runs before S17**: Session actions no longer blocked by cross-surface timeouts.
- **S11 expectations updated**: Tests server-side CWD persistence (after message send), not draft persistence (after blur).

### New Features
- **Server lifecycle**: `auto_start_server: "true"` starts `amp-distro serve` automatically and kills it on cleanup. Default `"false"` (expects server already running).
- **Screenshot directory**: `screenshot_dir` context var (default `/tmp/e2e-screenshots`). No more repo pollution.
- **Issue filing**: Approval gate after validation → `file-issues` stage creates GitHub issues for FAILs with full repro context via `gh issue create`.
- **Reproducibility**: `capture-context` step records git commit, branch, date, server URL in every report.

### Behavioral Improvements
- **Headless by default**: `browser_mode: "headless"` for CI. Override with `"headed"` to watch.
- **Resilience instructions**: All browser steps try 2-3 alternatives when UI changes, report BLOCKED when truly stuck, never fix bugs.
- **Don't-probe instruction**: Agents use ONLY the target URL. No port scanning, no server starts.
- **S04 criteria clarified**: SKIP = model finished too fast (timing). FAIL = stop acknowledged but no UI cancellation banner (bug).

### Recipe Structure (6 stages)
```
server-setup    → [start-server, capture-context]
chat-tests      → [S01-05, S06-11, S12-16, S18-25, S17] + approval gate
slack-tests     → [S1-S8]
validate        → [final-validation] + approval gate (file issues?)
file-issues     → [create-issues]
cleanup         → [cleanup]
```

### Context Variables
| Variable | Default | Purpose |
|----------|---------|---------|
| `server_url` | `http://127.0.0.1:8400` | Server URL (http or https) |
| `auto_start_server` | `"false"` | `"true"` = recipe manages server lifecycle |
| `browser_mode` | `"headless"` | `"headless"` or `"headed"` |
| `browser_setup` | `""` | CDP connection instructions |
| `screenshot_dir` | `/tmp/e2e-screenshots` | Screenshot output directory |
| `target_repo` | `microsoft/amplifier-distro` | GitHub repo for issue filing |
| `slack_workspace` | `https://amplifiercrew.slack.com/` | Slack workspace |
| `slack_channel` | `amplifier` | Slack channel |

### Usage
```bash
# Standard headless run (starts own server)
amplifier tool invoke recipes operation=execute \
  recipe_path=.amplifier/recipes/e2e-browser-tests.yaml \
  context='{"auto_start_server": "true"}'

# Watch tests in Chrome (user-provided server)
amplifier tool invoke recipes operation=execute \
  recipe_path=.amplifier/recipes/e2e-browser-tests.yaml \
  context='{"browser_mode": "headed"}'

# HTTPS + custom port
amplifier tool invoke recipes operation=execute \
  recipe_path=.amplifier/recipes/e2e-browser-tests.yaml \
  context='{"server_url": "https://127.0.0.1:8443"}'

# CDP to Edge RDP
amplifier tool invoke recipes operation=execute \
  recipe_path=.amplifier/recipes/e2e-browser-tests.yaml \
  context='{"browser_setup": "agent-browser connect 9222 && agent-browser tab new"}'
```
