### PR TITLE
docs: add documentation index and improve Slack setup token UX

### DIFF
--- a/distro-server/src/amplifier_distro/server/apps/slack/static/slack-setup.html
+++ b/distro-server/src/amplifier_distro/server/apps/slack/static/slack-setup.html
@@ -126,6 +126,18 @@ body {
   letter-spacing: 0.5px;
 }
 
+.field-hint {
+  margin: 0 0 2px;
+  font-size: 13px;
+  color: var(--ink);
+}
+
+.field-note {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--ink-slate);
+}
+
 .field input, .field select {
   width: 100%;
   padding: 10px 14px;
@@ -356,20 +368,21 @@ body {
     </div>
     <div class="step-body">
       <p class="step-hint">
-        After installing the app: copy the <strong>Bot Token</strong> from
-        OAuth &amp; Permissions, and the <strong>App Token</strong> from
-        Basic Information &gt; App-Level Tokens
-        (create one with <code>connections:write</code> scope).
+        After installing the app, grab these two tokens from your
+        <a href="https://api.slack.com/apps" target="_blank" rel="noopener">Slack app</a> settings:
       </p>
       <div class="field">
-        <label for="botToken">Bot Token</label>
-        <input type="password" id="botToken" placeholder="xoxb-..." autocomplete="off" spellcheck="false">
-        <div class="validation none" id="botStatus">Paste your Bot User OAuth Token</div>
+        <label for="appToken">App Token</label>
+        <p class="field-hint">Settings &gt; Basic Information &gt; App-Level Tokens</p>
+        <p class="field-note">Create one with <code>connections:write</code> scope.</p>
+        <input type="password" id="appToken" placeholder="xapp-..." autocomplete="off" spellcheck="false">
+        <div class="validation none" id="appStatus"></div>
       </div>
       <div class="field">
-        <label for="appToken">App Token</label>
-        <input type="password" id="appToken" placeholder="xapp-..." autocomplete="off" spellcheck="false">
-        <div class="validation none" id="appStatus">Paste your App-Level Token</div>
+        <label for="botToken">Bot Token</label>
+        <p class="field-hint">Features &gt; OAuth &amp; Permissions &gt; OAuth Tokens</p>
+        <input type="password" id="botToken" placeholder="xoxb-..." autocomplete="off" spellcheck="false">
+        <div class="validation none" id="botStatus"></div>
       </div>
       <button class="btn btn-primary" id="validateBtn" disabled>Validate Tokens</button>
       <div id="validateFeedback"></div>
@@ -511,20 +524,22 @@ function updateValidateBtn() {
   const app = appToken.value.trim();
   validateBtn.disabled = !bot.startsWith('xoxb-');
 
-  if (bot && !bot.startsWith('xoxb-')) {
-    showValidation(botStatus, 'fail', 'Must start with xoxb-');
-  } else if (bot) {
-    showValidation(botStatus, 'none', 'Ready to validate');
-  } else {
-    showValidation(botStatus, 'none', 'Paste your Bot User OAuth Token');
-  }
-
   if (app && !app.startsWith('xapp-')) {
     showValidation(appStatus, 'fail', 'Must start with xapp-');
   } else if (app) {
     showValidation(appStatus, 'none', 'Ready to validate');
   } else {
-    showValidation(appStatus, 'none', 'Paste your App-Level Token');
+    appStatus.className = 'validation none';
+    appStatus.innerHTML = '';
+  }
+
+  if (bot && !bot.startsWith('xoxb-')) {
+    showValidation(botStatus, 'fail', 'Must start with xoxb-');
+  } else if (bot) {
+    showValidation(botStatus, 'none', 'Ready to validate');
+  } else {
+    botStatus.className = 'validation none';
+    botStatus.innerHTML = '';
   }
 }
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,80 @@
+# amplifier-distro Documentation Index
+
+Quick-reference index for all documentation in this repository.
+
+---
+
+## Root
+
+| Document | Description |
+|----------|-------------|
+| [README.md](../README.md) | Project overview, install instructions, experience apps, provider configuration |
+| [SECURITY.md](../SECURITY.md) | Microsoft security vulnerability reporting process |
+| [AMPLIFIER_HOME_CONTRACT.md](../AMPLIFIER_HOME_CONTRACT.md) | Canonical spec for the `~/.amplifier/` filesystem layout and path derivation rules |
+
+---
+
+## Architecture & Reviews
+
+| Document | Description |
+|----------|-------------|
+| [voice-architecture.md](voice-architecture.md) | Voice app design reference -- WebRTC-first constraint, dual-session identity model |
+| [voice-realtime-review.md](voice-realtime-review.md) | Technical review of Voice app OpenAI Realtime API integration |
+| [DELEGATION-COMPARISON.md](DELEGATION-COMPARISON.md) | Cross-app analysis of delegation/sub-session spawning (CLI, Chat, Slack, Voice) |
+
+---
+
+## Design Documents
+
+Architectural specs describing the *what* and *why* of a feature.
+
+| Date | Document | Feature |
+|------|----------|---------|
+| 2026-07-08 | [session-name-editing-design](plans/2026-07-08-session-name-editing-design.md) | Inline session renaming in chat sidebar |
+| 2026-03-10 | [session-history-perf-design](plans/2026-03-10-session-history-perf-design.md) | Performance fix for session history loading |
+| 2026-03-03 | [secure-remote-access-design](plans/2026-03-03-secure-remote-access-design.md) | Four-layer secure remote access for voice app |
+| 2026-03-03 | [brand-alignment-theme-design](plans/2026-03-03-brand-alignment-theme-design.md) | Theme redesign aligned with withamplifier brand |
+| 2026-03-01 | [chat-to-voice-design](plans/2026-03-01-chat-to-voice-design.md) | Voice app resuming any Amplifier session |
+| 2026-02-28 | [cross-device-websocket-design](plans/2026-02-28-cross-device-websocket-design.md) | WebSocket disconnection fix for LAN devices |
+| 2026-02-27 | [delegation-feedback-design](plans/2026-02-27-delegation-feedback-design.md) | Visual/vocal delegation feedback in voice app |
+| 2026-02-27 | [service-commands-fix-design](plans/2026-02-27-service-commands-amp-distro-fix-design.md) | Fix `amp-distro service` command routing |
+| 2026-02-27 | [handoff-injection-design](plans/2026-02-27-handoff-injection-design.md) | Auto-inject recent project handoff into sessions |
+| 2026-02-27 | [distro-remaining-issues](plans/2026-02-27-distro-remaining-issues.md) | Umbrella design for 6 outstanding issues |
+
+---
+
+## Implementation Plans
+
+Step-by-step TDD task lists describing *how* to build a feature.
+
+| Date | Document | Feature |
+|------|----------|---------|
+| 2026-07-08 | [session-name-editing-impl](plans/2026-07-08-session-name-editing-implementation.md) | Session renaming -- backend protocol, WebSocket broadcast, frontend edit mode |
+| 2026-03-03 | [secure-remote-access-impl](plans/2026-03-03-secure-remote-access-implementation.md) | TLS, PAM auth, CSRF, browser secure-context guard |
+| 2026-03-03 | [web-chat-responsiveness](plans/2026-03-03-web-chat-responsiveness-improvements.md) | Client-side thinking placeholder, orchestrator event surfacing |
+| 2026-03-01 | [chat-to-voice-plan v2](plans/2026-03-01-chat-to-voice-plan.md) | Chat-to-voice handoff (revised 9-task plan) |
+| 2026-02-27 | [chat-to-voice v1](plans/2026-02-27-chat-to-voice.md) | Chat-to-voice handoff (original 8-task plan) |
+| 2026-02-27 | [fix-approval-display](plans/2026-02-27-fix-approval-display-plan.md) | `SessionSurface` abstraction replacing `event_queue` |
+| 2026-02-27 | [fix-bundle-prewarm](plans/2026-02-27-fix-bundle-prewarm-plan.md) | Bundle pre-warming at server startup |
+| 2026-02-27 | [service-commands-fix-impl](plans/2026-02-27-service-commands-amp-distro-fix-implementation.md) | Service command routing through `amp-distro` binary |
+| 2026-02-27 | [fix-slack-aiohttp](plans/2026-02-27-fix-slack-aiohttp-plan.md) | Slack aiohttp session lifecycle cleanup |
+| 2026-02-27 | [fix-overlay-hooks](plans/2026-02-27-fix-overlay-hooks-plan.md) | Move session-naming hook into default bundle |
+| 2026-02-27 | [fix-await-cancel](plans/2026-02-27-fix-await-cancel-plan.md) | Async correctness: missing await + CWD guard |
+| 2026-02-26 | [session-spawning](plans/2026-02-26-session-spawning.md) | Register `session.spawn` capability in `FoundationBackend` |
+
+---
+
+## Testing
+
+| Document | Description |
+|----------|-------------|
+| [E2E Test Recipes](../.amplifier/recipes/README.md) | Staged E2E test system -- 27 scenarios across chat, cross-surface, and Slack |
+
+---
+
+## Navigating This Repository
+
+- **Design docs** describe the approach for a feature and are useful for understanding intent and trade-offs.
+- **Implementation plans** are paired with their design docs and contain TDD task lists with exact file paths -- designed for agent-driven execution.
+- The **chat-to-voice** feature has two generations of plans (Feb 27 and Mar 1), reflecting design evolution.
+- Several small "summary stub" files in `plans/` act as commit receipts pointing to the full documents and are not listed here.


### PR DESCRIPTION
## What

Two improvements to developer experience:

1. **Documentation index** (`docs/INDEX.md`) -- a navigable entry point for the
   26 design documents and implementation plans in `docs/plans/`, plus root-level
   docs and architecture references.

2. **Slack setup wizard token UX** -- reordered and clarified the token input
   step at `/apps/slack/setup-ui`.

## Why

### Documentation index

The `docs/plans/` directory has grown to 26 files -- paired design specs and
TDD implementation plans spanning Feb-Jul 2026. There was no way to discover
what exists without listing the directory. The index categorizes documents by
type (architecture, design, implementation) and summarizes each one in a
sentence.

This serves both human developers browsing on GitHub and AI agents working in
the codebase -- giving them a structured map of the project's documentation
rather than requiring a directory scan to understand what's available.

### Slack setup token ordering

When setting up the Slack connector for the first time, the wizard asked for
the Bot Token first and the App Token second. In practice the Slack admin UI
leads you to the App Token first (Settings > Basic Information > App-Level
Tokens) before you reach the Bot Token (Features > OAuth & Permissions).
The original form gave a single paragraph of instructions for both tokens,
which was easy to skim past.

The new layout:
- Puts App Token first to match the natural Slack UI navigation order
- Adds a breadcrumb path above each input showing exactly where to find
  the token in Slack's settings
- Notes the required `connections:write` scope inline with the App Token
- Links directly to api.slack.com/apps in the intro text
- Keeps validation messages clean -- they only appear on user interaction,
  since the static breadcrumbs already provide the guidance

## Changes

| File | Change |
|------|--------|
| `docs/INDEX.md` | New file -- documentation index with relative links |
| `slack-setup.html` | Reorder fields, add `.field-hint`/`.field-note` CSS, update JS validation |

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)