### PR TITLE
feat(slack): Phase 3 — Browser automation for near-zero-click Slack setup

### DIFF
--- a/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup.py
+++ b/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup.py
@@ -21,6 +21,8 @@ The setup flow:
 
 from __future__ import annotations
 
+import copy
+import json
 import logging
 import os
 from pathlib import Path
@@ -28,7 +30,8 @@ from typing import Any
 
 import httpx
 import yaml
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -281,9 +284,15 @@ async def setup_status() -> dict[str, Any]:
 
     bot_token = os.environ.get("SLACK_BOT_TOKEN", "") or keys.get("SLACK_BOT_TOKEN", "")
     app_token = os.environ.get("SLACK_APP_TOKEN", "") or keys.get("SLACK_APP_TOKEN", "")
-    hub_channel_id = os.environ.get("SLACK_HUB_CHANNEL_ID", "") or cfg.get("hub_channel_id", "")
+    hub_channel_id = os.environ.get("SLACK_HUB_CHANNEL_ID", "") or cfg.get(
+        "hub_channel_id", ""
+    )
     sm_env = os.environ.get("SLACK_SOCKET_MODE", "")
-    socket_mode = sm_env.lower() in ("1", "true", "yes") if sm_env else cfg.get("socket_mode", False)
+    socket_mode = (
+        sm_env.lower() in ("1", "true", "yes")
+        if sm_env
+        else cfg.get("socket_mode", False)
+    )
 
     steps = {
         "bot_token": bool(bot_token),
@@ -484,3 +493,66 @@ async def get_manifest() -> dict[str, Any]:
         ),
         "create_url": "https://api.slack.com/apps?new_app=1",
     }
+
+
+@router.post("/automate")
+async def automate_setup(request: Request) -> dict[str, Any]:
+    """Launch browser automation to create and configure the Slack app."""
+    from .setup_automation import automate_slack_setup, check_agent_browser
+
+    if not check_agent_browser():
+        return JSONResponse(
+            {
+                "error": "agent-browser not installed",
+                "install_cmd": "npm install -g agent-browser && agent-browser install",
+            },
+            status_code=424,
+        )
+
+    manifest = copy.deepcopy(SLACK_APP_MANIFEST)
+    manifest_yaml_str = yaml.dump(manifest, default_flow_style=False, sort_keys=False)
+    result = await automate_slack_setup(manifest_yaml_str)
+
+    if result.success:
+        _save_keys(
+            {
+                "SLACK_BOT_TOKEN": result.bot_token,
+                "SLACK_APP_TOKEN": result.app_token,
+            }
+        )
+        os.environ["SLACK_BOT_TOKEN"] = result.bot_token
+        os.environ["SLACK_APP_TOKEN"] = result.app_token
+        return {"success": True, "message": "Slack app created and configured!"}
+
+    return {
+        "success": False,
+        "error": result.error,
+        "step_reached": result.step_reached,
+        "partial_tokens": {
+            "bot_token": bool(result.bot_token),
+            "app_token": bool(result.app_token),
+        },
+    }
+
+
+@router.get("/automate/status")
+async def automate_status(request: Request) -> Any:
+    """SSE stream of automation progress; falls back to plain JSON."""
+    from .setup_automation import get_automation_status
+
+    try:
+        from sse_starlette.sse import EventSourceResponse
+
+        async def _generate():
+            while True:
+                status = get_automation_status()
+                yield {"event": "progress", "data": json.dumps(status)}
+                if status.get("complete"):
+                    break
+                import asyncio
+
+                await asyncio.sleep(1)
+
+        return EventSourceResponse(_generate())
+    except ImportError:
+        return get_automation_status()

--- a/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup_automation.py
+++ b/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup_automation.py
@@ -1,0 +1,191 @@
+"""
+Slack setup automation via agent-browser.
+
+Automates manual steps of Slack app creation:
+1. Navigate to Slack app creation with pre-filled manifest
+2. Walk through creation wizard (select workspace, review, create)
+3. Generate App-Level Token (xapp-) — this CANNOT be done via any API
+4. Install app to workspace
+5. Retrieve Bot Token (xoxb-)
+6. Return both tokens
+"""
+import asyncio
+import subprocess
+import json
+import re
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Thread-safe automation status for SSE streaming
+_automation_status: dict[str, Any] = {}
+_status_lock = threading.Lock()
+
+@dataclass
+class AutomationResult:
+    success: bool
+    bot_token: str = ""
+    app_token: str = ""
+    error: str = ""
+    step_reached: str = ""
+
+def get_automation_status() -> dict[str, Any]:
+    with _status_lock:
+        return dict(_automation_status)
+
+def _set_status(step: str, detail: str, complete: bool = False):
+    with _status_lock:
+        _automation_status.update({"step": step, "detail": detail, "complete": complete})
+
+def _run_browser_cmd(*args: str, timeout: int = 30) -> str:
+    result = subprocess.run(
+        ["agent-browser", *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"agent-browser failed: {result.stderr.strip()}")
+    return result.stdout
+
+def check_agent_browser() -> bool:
+    try:
+        result = subprocess.run(["agent-browser", "--version"], capture_output=True, text=True, timeout=10)
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+def _find_ref(snapshot: str, *keywords: str) -> str | None:
+    """Find an element ref (@eN) from snapshot lines matching ALL keywords."""
+    for line in snapshot.strip().split("\n"):
+        lower = line.lower()
+        if all(kw.lower() in lower for kw in keywords):
+            m = re.search(r"(@e\d+)", line)
+            if m:
+                return m.group(1)
+    return None
+
+async def automate_slack_setup(manifest_yaml: str) -> AutomationResult:
+    import urllib.parse
+
+    if not check_agent_browser():
+        return AutomationResult(
+            success=False,
+            error="agent-browser not installed. Install: npm install -g agent-browser && agent-browser install",
+            step_reached="preflight",
+        )
+
+    encoded = urllib.parse.quote(manifest_yaml)
+    url = f"https://api.slack.com/apps?new_app=1&manifest_yaml={encoded}"
+
+    try:
+        _set_status("opening", "Opening Slack app creation page...")
+        _run_browser_cmd("open", url)
+        await asyncio.sleep(3)
+
+        snapshot = _run_browser_cmd("snapshot", "-ic")
+        if "sign in" in snapshot.lower() or "email" in snapshot.lower():
+            _set_status("login_required", "Please log into Slack in the browser window", complete=True)
+            return AutomationResult(success=False, error="Please log into Slack, then retry.", step_reached="login_required")
+
+        _set_status("creating", "Navigating app creation wizard...")
+        result = await _navigate_creation_wizard()
+        if not result.success:
+            _set_status("failed", result.error, complete=True)
+            return result
+
+        _set_status("app_token", "Generating App-Level Token...")
+        app_token = await _generate_app_level_token()
+        if not app_token:
+            _set_status("partial", "App-Level Token generation failed", complete=True)
+            return AutomationResult(success=False, error="Failed to generate app-level token.", step_reached="app_token")
+
+        _set_status("installing", "Installing app to workspace...")
+        bot_token = await _install_and_get_bot_token()
+        if not bot_token:
+            _set_status("partial", "Bot token retrieval failed", complete=True)
+            return AutomationResult(success=False, app_token=app_token, error="Failed to get bot token.", step_reached="bot_token")
+
+        _run_browser_cmd("close")
+        _set_status("done", "Setup complete!", complete=True)
+        return AutomationResult(success=True, bot_token=bot_token, app_token=app_token)
+    except Exception as e:
+        logger.exception("Automation failed")
+        _set_status("error", str(e), complete=True)
+        return AutomationResult(success=False, error=str(e), step_reached="unknown")
+
+async def _navigate_creation_wizard() -> AutomationResult:
+    for _ in range(5):
+        await asyncio.sleep(2)
+        snapshot = _run_browser_cmd("snapshot", "-ic")
+        if "basic information" in snapshot.lower() or "app-level tokens" in snapshot.lower():
+            return AutomationResult(success=True, step_reached="app_created")
+        for label in ["next", "create"]:
+            ref = _find_ref(snapshot, label)
+            if ref:
+                _run_browser_cmd("click", ref)
+                await asyncio.sleep(2)
+                break
+    return AutomationResult(success=False, error="Could not navigate creation wizard", step_reached="wizard")
+
+async def _generate_app_level_token() -> str:
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "generate token") or _find_ref(snapshot, "app-level token")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(2)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "name")
+    if ref:
+        _run_browser_cmd("fill", ref, "amplifier")
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "scope") or _find_ref(snapshot, "connections:write")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(1)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "generate")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(2)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    m = re.search(r"(xapp-\S+)", snapshot)
+    return m.group(1) if m else ""
+
+async def _install_and_get_bot_token() -> str:
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "oauth", "permission")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(2)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "install", "workspace")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(3)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    ref = _find_ref(snapshot, "allow")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(3)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    m = re.search(r"(xoxb-\S+)", snapshot)
+    if m:
+        return m.group(1)
+
+    ref = _find_ref(snapshot, "copy") or _find_ref(snapshot, "show") or _find_ref(snapshot, "reveal")
+    if ref:
+        _run_browser_cmd("click", ref)
+        await asyncio.sleep(1)
+
+    snapshot = _run_browser_cmd("snapshot", "-ic")
+    m = re.search(r"(xoxb-\S+)", snapshot)
+    return m.group(1) if m else ""

--- a/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/static/slack-setup.html
+++ b/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/static/slack-setup.html
@@ -327,6 +327,96 @@ body {
 }
 
 .footer a:hover { text-decoration: underline; }
+
+/* ------------------------------------------------------------------ */
+/*  Setup Mode Choice                                                  */
+/* ------------------------------------------------------------------ */
+.setup-choice {
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--canvas-mist);
+}
+
+.setup-choice h2 {
+  font-size: 17px;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.choice-cards {
+  display: flex;
+  gap: 12px;
+}
+
+.choice-card {
+  flex: 1;
+  padding: 18px;
+  border: 1px solid var(--canvas-mist);
+  border-radius: var(--radius-card);
+  background: var(--canvas-stone);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  transition: border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}
+
+.choice-card:hover {
+  border-color: var(--signal);
+  background: var(--canvas);
+}
+
+.choice-card h3 {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.choice-card p {
+  margin: 0 0 4px;
+  font-size: 13px;
+  color: var(--ink-slate);
+}
+
+.choice-card small {
+  font-size: 12px;
+  color: var(--ink-fog);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Automation Progress Panel                                          */
+/* ------------------------------------------------------------------ */
+.automation-panel {
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--canvas-mist);
+}
+
+.automation-panel h2 {
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.automation-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--canvas-stone);
+  border: 1px solid var(--canvas-mist);
+  border-radius: var(--radius-input);
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+
+.automation-progress .spinner {
+  flex-shrink: 0;
+  border-color: rgba(128,128,128,0.25);
+  border-top-color: var(--signal);
+}
 </style>
 </head>
 <body>
@@ -334,6 +424,41 @@ body {
   <h1 class="wordmark wordmark-sm">amplifier</h1>
   <p style="color: var(--ink-slate); font-size: 1.1rem; margin-top: 8px; text-align: center;">Connect Slack</p>
   <p class="tagline">Bridge your Slack workspace to Amplifier</p>
+
+  <!-- ============================================================ -->
+  <!--  Setup Mode Choice                                           -->
+  <!-- ============================================================ -->
+  <div id="setup-mode-choice" class="setup-choice">
+    <h2>How would you like to set up Slack?</h2>
+    <div class="choice-cards">
+      <button onclick="startAutomatedSetup()" class="choice-card">
+        <h3>⚡ Automated Setup</h3>
+        <p>~2 minutes. Browser automation handles most steps.</p>
+        <small>Requires: agent-browser installed</small>
+      </button>
+      <button onclick="startManualSetup()" class="choice-card">
+        <h3>📋 Manual Setup</h3>
+        <p>~5–10 minutes. Step-by-step guided instructions.</p>
+      </button>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!--  Automation Progress Panel (hidden by default)              -->
+  <!-- ============================================================ -->
+  <div id="automation-panel" class="automation-panel" style="display:none">
+    <h2>Automated Setup</h2>
+    <div id="automation-progress" class="automation-progress" style="display:none">
+      <span class="spinner"></span>
+      <span id="automation-status">Starting...</span>
+    </div>
+    <div id="automation-feedback"></div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!--  Manual Wizard (hidden by default)                          -->
+  <!-- ============================================================ -->
+  <div id="manual-wizard" style="display:none">
 
   <!-- ============================================================ -->
   <!--  Step 1: Create App                                           -->
@@ -430,6 +555,8 @@ body {
       <div id="saveFeedback"></div>
     </div>
   </div>
+
+  </div><!-- /#manual-wizard -->
 
   <div class="footer">
     <a href="/distro/settings">Back to settings</a>
@@ -732,7 +859,9 @@ async function checkExisting() {
     const data = await res.json();
 
     if (data.configured) {
-      // Already configured - show success state
+      // Already configured — skip choice, show the wizard in all-done state
+      document.getElementById('setup-mode-choice').style.display = 'none';
+      document.getElementById('manual-wizard').style.display = 'block';
       markDone(step1);
       enableStep(step2);
       markDone(step2);
@@ -745,7 +874,99 @@ async function checkExisting() {
         esc(data.mode) + '). Re-run setup to change settings.</div>';
     }
   } catch {
-    // Ignore - just show the fresh setup flow
+    // Ignore — just show the fresh setup flow
+  }
+}
+
+// --- Two-path setup ---
+
+function startManualSetup() {
+  document.getElementById('setup-mode-choice').style.display = 'none';
+  document.getElementById('manual-wizard').style.display = 'block';
+}
+
+function switchToManual(e) {
+  if (e) e.preventDefault();
+  document.getElementById('automation-panel').style.display = 'none';
+  document.getElementById('manual-wizard').style.display = 'block';
+}
+
+async function startAutomatedSetup() {
+  document.getElementById('setup-mode-choice').style.display = 'none';
+  const panel = document.getElementById('automation-panel');
+  panel.style.display = 'block';
+
+  const progressEl = document.getElementById('automation-progress');
+  const statusEl   = document.getElementById('automation-status');
+  const feedbackEl = document.getElementById('automation-feedback');
+
+  progressEl.style.display = 'flex';
+  statusEl.textContent = 'Starting automation…';
+
+  // Listen for SSE progress stream (best-effort)
+  let es = null;
+  try {
+    es = new EventSource(API + '/automate/status');
+    es.addEventListener('progress', (e) => {
+      try {
+        const s = JSON.parse(e.data);
+        const label = s.step  ? '<strong>' + esc(s.step) + '</strong>: ' : '';
+        statusEl.innerHTML = label + esc(s.detail || '');
+        if (s.complete) { es.close(); es = null; }
+      } catch { /* ignore parse errors */ }
+    });
+    es.onerror = () => { if (es) { es.close(); es = null; } };
+  } catch { /* SSE not supported */ }
+
+  // Kick off the automation POST
+  try {
+    const res = await fetch(API + '/automate', { method: 'POST' });
+    if (es) { es.close(); es = null; }
+
+    progressEl.style.display = 'none';
+    const data = await res.json();
+
+    if (data.success) {
+      feedbackEl.innerHTML =
+        '<div class="success-msg">' +
+        '✓ Slack app created and tokens saved!<br>' +
+        '<a href="#" onclick="location.reload();return false;">Reload to configure your hub channel →</a>' +
+        '</div>';
+    } else if (res.status === 424) {
+      // agent-browser missing
+      feedbackEl.innerHTML =
+        '<div class="error-msg">agent-browser is not installed.<br>' +
+        '<code>' + esc(data.install_cmd || '') + '</code></div>' +
+        '<p style="margin-top:12px;font-size:13px;text-align:center">' +
+        '<a href="#" onclick="switchToManual(event)">Switch to Manual Setup →</a></p>';
+    } else {
+      // Partial failure
+      const partial = data.partial_tokens || {};
+      let msg = '<div class="error-msg">Automation stopped at step ' +
+        '<strong>' + esc(data.step_reached || 'unknown') + '</strong>';
+      if (data.error) msg += '<br>' + esc(data.error);
+      msg += '</div>';
+      if (partial.app_token || partial.bot_token) {
+        msg += '<div class="success-msg" style="margin-top:8px">Some tokens were retrieved — ' +
+          'switch to manual setup to enter the missing ones.</div>';
+      }
+      msg += '<p style="margin-top:12px;font-size:13px;text-align:center">' +
+        '<a href="#" onclick="switchToManual(event)">Switch to Manual Setup →</a></p>';
+      feedbackEl.innerHTML = msg;
+
+      // Pre-fill any partial tokens the automation did retrieve
+      if (data.partial_tokens) {
+        if (data.partial_bot_token)  { botToken.value  = data.partial_bot_token;  }
+        if (data.partial_app_token)  { appToken.value  = data.partial_app_token;  }
+      }
+    }
+  } catch (err) {
+    if (es) { es.close(); es = null; }
+    progressEl.style.display = 'none';
+    feedbackEl.innerHTML =
+      '<div class="error-msg">' + esc(err.message) + '</div>' +
+      '<p style="margin-top:12px;font-size:13px;text-align:center">' +
+      '<a href="#" onclick="switchToManual(event)">Switch to Manual Setup →</a></p>';
   }
 }
 


### PR DESCRIPTION
## Summary

Uses `agent-browser` CLI to automate the manual Slack UI steps that cannot be done via API — particularly generating the App-Level Token (`xapp-`) which has no programmatic equivalent.

### Changes

1. **`setup_automation.py`** (new module) — Orchestrates browser automation:
   - Opens Slack app creation with pre-filled manifest
   - Navigates creation wizard (Next → Next → Create)
   - Generates App-Level Token with `connections:write` scope
   - Installs app to workspace
   - Scrapes both `xapp-` and `xoxb-` tokens from the page
   - Returns tokens to the caller

2. **`POST /setup/automate`** — Triggers full automation, auto-saves tokens on success. Returns HTTP 424 if `agent-browser` is not installed.

3. **`GET /setup/automate/status`** — SSE stream for real-time progress updates. Degrades to JSON if `sse-starlette` is not installed.

4. **Two-path setup UI** — User chooses "Automated Setup" (~2 min) or "Manual Setup" (~5-10 min). Automated path shows live progress with graceful fallback to manual on any failure.

### Graceful degradation

- `agent-browser` not installed → shows install command, falls back to manual
- Slack login needed → prompts user to log in, offers retry
- Any step fails → saves partial progress, falls back to manual for remaining steps
- One token captured but not the other → pre-fills what was captured

### Prerequisites

```bash
npm install -g agent-browser
agent-browser install
```

Part 3 of 3 in the Slack setup simplification effort.
- Phase 1: Quick wins (#TBD)
- Phase 2: OAuth flow (#TBD)
- Phase 3: Browser automation (this PR)