### PR TITLE
feat(slack): Phase 2 — OAuth install flow for automated bot token capture

### DIFF
--- a/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup.py
+++ b/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/setup.py
@@ -21,14 +21,19 @@ The setup flow:
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
+import secrets
+import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import httpx
 import yaml
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -42,6 +47,11 @@ _PLUGIN_CONFIG_DIR = "plugins/slack"
 _PLUGIN_CONFIG_FILE = "config.yaml"
 
 # --- The Slack App Manifest (for one-click app creation) ---
+
+_oauth_states: dict[str, float] = {}  # state_token -> expiry timestamp
+_oauth_pending: dict[
+    str, dict
+] = {}  # state_token -> {client_id, client_secret, redirect_uri}
 
 SLACK_APP_MANIFEST = {
     "display_information": {
@@ -101,6 +111,11 @@ class ValidateRequest(BaseModel):
     app_token: str = ""
 
 
+class OAuthBeginRequest(BaseModel):
+    client_id: str
+    client_secret: str
+
+
 class ConfigureRequest(BaseModel):
     bot_token: str
     app_token: str = ""
@@ -108,6 +123,8 @@ class ConfigureRequest(BaseModel):
     hub_channel_id: str = ""
     hub_channel_name: str = "amplifier"
     socket_mode: bool = True
+    client_id: str = ""
+    client_secret: str = ""
 
 
 class TestRequest(BaseModel):
@@ -270,6 +287,69 @@ async def _list_channels(token: str, *, limit: int = 200) -> list[dict[str, Any]
     ]
 
 
+# --- OAuth helpers ---
+
+
+def _create_oauth_state() -> str:
+    """Create a CSRF state token with 10-minute TTL, pruning expired entries."""
+    now = time.time()
+    expired = [k for k, v in _oauth_states.items() if v < now]
+    for k in expired:
+        _oauth_states.pop(k, None)
+        _oauth_pending.pop(k, None)
+
+    state = secrets.token_urlsafe(32)
+    _oauth_states[state] = now + 600  # 10 minutes
+    return state
+
+
+def _validate_oauth_state(state: str) -> bool:
+    """Validate and consume a CSRF state token. Returns False if missing/expired."""
+    expiry = _oauth_states.pop(state, None)
+    if expiry is None:
+        return False
+    return time.time() < expiry
+
+
+def _error_page(message: str) -> HTMLResponse:
+    """Return a styled HTML error page for OAuth failures."""
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Setup Error — Amplifier Slack</title>
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<script src="/static/theme-init.js"></script>
+<link rel="stylesheet" href="/static/amplifier-theme.css">
+<style>
+  *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{ display: flex; align-items: center; justify-content: center;
+          min-height: 100vh; font-family: var(--font-body);
+          background: var(--canvas); color: var(--ink); padding: 20px; }}
+  .card {{ background: var(--canvas-warm); border: 1px solid var(--canvas-mist);
+           border-radius: var(--radius-card); padding: 48px 40px;
+           max-width: 480px; width: 100%; box-shadow: var(--shadow-lift);
+           text-align: center; }}
+  h2 {{ font-size: 20px; font-weight: 700; color: var(--error); margin-bottom: 16px; }}
+  p {{ color: var(--ink-slate); margin-bottom: 28px; font-size: 15px; line-height: 1.6; }}
+  a {{ display: inline-flex; align-items: center; gap: 6px; color: var(--signal);
+       text-decoration: none; font-weight: 600; font-size: 14px; }}
+  a:hover {{ text-decoration: underline; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1 class="wordmark wordmark-sm">amplifier</h1>
+  <h2 style="margin-top:16px;">Setup Error</h2>
+  <p>{message}</p>
+  <a href="/slack/setup-ui">&#8592; Back to Setup</a>
+</div>
+</body>
+</html>"""
+    return HTMLResponse(content=html, status_code=400)
+
+
 # --- Routes ---
 
 
@@ -281,9 +361,15 @@ async def setup_status() -> dict[str, Any]:
 
     bot_token = os.environ.get("SLACK_BOT_TOKEN", "") or keys.get("SLACK_BOT_TOKEN", "")
     app_token = os.environ.get("SLACK_APP_TOKEN", "") or keys.get("SLACK_APP_TOKEN", "")
-    hub_channel_id = os.environ.get("SLACK_HUB_CHANNEL_ID", "") or cfg.get("hub_channel_id", "")
+    hub_channel_id = os.environ.get("SLACK_HUB_CHANNEL_ID", "") or cfg.get(
+        "hub_channel_id", ""
+    )
     sm_env = os.environ.get("SLACK_SOCKET_MODE", "")
-    socket_mode = sm_env.lower() in ("1", "true", "yes") if sm_env else cfg.get("socket_mode", False)
+    socket_mode = (
+        sm_env.lower() in ("1", "true", "yes")
+        if sm_env
+        else cfg.get("socket_mode", False)
+    )
 
     steps = {
         "bot_token": bool(bot_token),
@@ -381,6 +467,8 @@ async def configure(req: ConfigureRequest) -> dict[str, Any]:
             "SLACK_BOT_TOKEN": req.bot_token,
             "SLACK_APP_TOKEN": req.app_token,
             "SLACK_SIGNING_SECRET": req.signing_secret,
+            "SLACK_CLIENT_ID": req.client_id,
+            "SLACK_CLIENT_SECRET": req.client_secret,
         }
     )
 
@@ -462,25 +550,113 @@ async def test_connection(req: TestRequest) -> dict[str, Any]:
 
 
 @router.get("/manifest")
-async def get_manifest() -> dict[str, Any]:
-    """Return the Slack App Manifest for one-click app creation."""
-    manifest_yaml = yaml.dump(
-        SLACK_APP_MANIFEST, default_flow_style=False, sort_keys=False
+async def get_manifest(request: Request) -> dict[str, Any]:
+    """Return the Slack App Manifest with a dynamic redirect_url injected."""
+    manifest = copy.deepcopy(SLACK_APP_MANIFEST)
+    base = str(request.base_url).rstrip("/")
+    callback = f"{base}/slack/setup/oauth/callback"
+    manifest["oauth_config"]["redirect_urls"] = [callback]
+
+    manifest_yaml = yaml.dump(manifest, default_flow_style=False, sort_keys=False)
+    create_url = "https://api.slack.com/apps?new_app=1&manifest_yaml=" + quote(
+        manifest_yaml
     )
+
     return {
-        "manifest": SLACK_APP_MANIFEST,
+        "manifest": manifest,
         "manifest_yaml": manifest_yaml,
-        "instructions": (
-            "1. Go to https://api.slack.com/apps\n"
-            "2. Click 'Create New App' > 'From a manifest'\n"
-            "3. Select your workspace\n"
-            "4. Choose YAML format and paste the manifest\n"
-            "5. Click 'Create'\n"
-            "6. Go to 'Install App' and install to your workspace\n"
-            "7. Copy the Bot Token (xoxb-...) from OAuth & Permissions\n"
-            "8. Copy the App Token (xapp-...) from Basic Information\n"
-            "   > App-Level Tokens (create one with 'connections:write')\n"
-            "9. Use /setup/configure to save both tokens"
-        ),
-        "create_url": "https://api.slack.com/apps?new_app=1",
+        "create_url": create_url,
     }
+
+
+@router.post("/oauth/begin")
+async def oauth_begin(req: OAuthBeginRequest, request: Request) -> JSONResponse:
+    """Start the OAuth install flow — returns a Slack authorize URL.
+
+    Enforces HTTPS because Slack only allows HTTPS redirect URIs.
+    """
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    if scheme != "https":
+        return JSONResponse(
+            {
+                "error": (
+                    "OAuth requires HTTPS. Restart with: amp-distro serve --tls auto"
+                )
+            },
+            status_code=400,
+        )
+
+    state = _create_oauth_state()
+    base = str(request.base_url).rstrip("/")
+    redirect_uri = f"{base}/slack/setup/oauth/callback"
+    _oauth_pending[state] = {
+        "client_id": req.client_id,
+        "client_secret": req.client_secret,
+        "redirect_uri": redirect_uri,
+    }
+
+    scopes = ",".join(SLACK_APP_MANIFEST["oauth_config"]["scopes"]["bot"])
+    auth_url = (
+        f"https://slack.com/oauth/v2/authorize"
+        f"?client_id={req.client_id}"
+        f"&scope={scopes}"
+        f"&redirect_uri={redirect_uri}"
+        f"&state={state}"
+    )
+    return JSONResponse({"authorize_url": auth_url})
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str = "",
+) -> HTMLResponse | RedirectResponse:
+    """Handle Slack's OAuth redirect — exchange code for bot token."""
+    if error:
+        return _error_page(f"Slack returned an error: {error}")
+
+    if not _validate_oauth_state(state):
+        return _error_page("Invalid or expired state. Please try again.")
+
+    pending = _oauth_pending.pop(state, None)
+    if not pending:
+        return _error_page("Session expired. Please restart the OAuth flow.")
+
+    # Exchange authorization code for bot token
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://slack.com/api/oauth.v2.access",
+            data={
+                "client_id": pending["client_id"],
+                "client_secret": pending["client_secret"],
+                "code": code,
+                "redirect_uri": pending["redirect_uri"],
+            },
+            timeout=15.0,
+        )
+        data = resp.json()
+
+    if not data.get("ok"):
+        return _error_page(f"Token exchange failed: {data.get('error', 'unknown')}")
+
+    bot_token = data.get("access_token", "")
+    team_name = data.get("team", {}).get("name", "")
+    app_id = data.get("app_id", "")
+    team_id = data.get("team", {}).get("id", "")
+
+    # Persist bot token and client credentials to keys.env
+    _save_keys(
+        {
+            "SLACK_BOT_TOKEN": bot_token,
+            "SLACK_CLIENT_ID": pending["client_id"],
+            "SLACK_CLIENT_SECRET": pending["client_secret"],
+        }
+    )
+    os.environ["SLACK_BOT_TOKEN"] = bot_token
+
+    params = urlencode(
+        {"oauth": "success", "team": team_name, "app_id": app_id, "team_id": team_id}
+    )
+    return RedirectResponse(f"/slack/setup-ui?{params}")

--- a/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/static/slack-setup.html
+++ b/amplifierd-plugins/amplifierd-plugin-slack/src/slack_plugin/static/slack-setup.html
@@ -58,6 +58,25 @@ body {
 }
 
 /* ------------------------------------------------------------------ */
+/*  OAuth Success Banner                                               */
+/* ------------------------------------------------------------------ */
+.oauth-banner {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  background: var(--success-soft);
+  border: 1px solid var(--success);
+  border-radius: var(--radius-subtle);
+  padding: 12px 16px;
+  margin-bottom: 24px;
+  font-size: 14px;
+  color: var(--success);
+  font-weight: 600;
+}
+
+.oauth-banner.visible { display: flex; }
+
+/* ------------------------------------------------------------------ */
 /*  Steps                                                              */
 /* ------------------------------------------------------------------ */
 .step {
@@ -173,6 +192,27 @@ body {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Instruction list                                                   */
+/* ------------------------------------------------------------------ */
+.instructions {
+  margin: 0 0 12px;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--ink-slate);
+  line-height: 1.8;
+}
+
+.instructions li { margin-bottom: 2px; }
+.instructions code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--canvas-stone);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--ink);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Manifest Box                                                       */
 /* ------------------------------------------------------------------ */
 .manifest-box {
@@ -240,7 +280,7 @@ body {
   padding: 12px 24px;
 }
 
-.btn-slack:hover { background: #4a154b; }
+.btn-slack:hover:not(:disabled) { background: #4a154b; }
 
 .btn-row {
   display: flex;
@@ -311,6 +351,16 @@ body {
   font-size: 13px;
 }
 
+.info-msg {
+  margin-top: 10px;
+  padding: 10px 14px;
+  background: var(--canvas-stone);
+  color: var(--ink-slate);
+  border: 1px solid var(--canvas-mist);
+  border-radius: var(--radius-subtle);
+  font-size: 13px;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Footer                                                             */
 /* ------------------------------------------------------------------ */
@@ -335,8 +385,14 @@ body {
   <p style="color: var(--ink-slate); font-size: 1.1rem; margin-top: 8px; text-align: center;">Connect Slack</p>
   <p class="tagline">Bridge your Slack workspace to Amplifier</p>
 
+  <!-- OAuth success banner (shown after redirect back from Slack) -->
+  <div class="oauth-banner" id="oauthBanner">
+    <span>&#10003;</span>
+    <span id="oauthBannerText">App installed! Bot token saved.</span>
+  </div>
+
   <!-- ============================================================ -->
-  <!--  Step 1: Create App                                           -->
+  <!--  Step 1: Create Slack App                                    -->
   <!-- ============================================================ -->
   <div class="step" id="step1">
     <div class="step-header">
@@ -345,8 +401,9 @@ body {
     </div>
     <div class="step-body">
       <p class="step-hint">
-        Click below to create an app with all permissions pre-configured.
-        Select your workspace, then click <strong>Create</strong>.
+        Click below to open the Slack app creation page with all permissions
+        pre-configured in the manifest. Select your workspace, then click
+        <strong>Create</strong>.
       </p>
       <div class="manifest-box" id="manifestBox">Loading manifest...</div>
       <div class="btn-row">
@@ -359,49 +416,79 @@ body {
   </div>
 
   <!-- ============================================================ -->
-  <!--  Step 2: Paste Tokens                                         -->
+  <!--  Step 2: Connect Your App (OAuth)                            -->
   <!-- ============================================================ -->
   <div class="step disabled" id="step2">
     <div class="step-header">
       <span class="step-num">2</span>
-      <span class="step-title">Paste Tokens</span>
+      <span class="step-title">Connect Your App</span>
     </div>
     <div class="step-body">
       <p class="step-hint">
-        After installing the app, grab these two tokens from your
-        <a href="https://api.slack.com/apps" target="_blank" rel="noopener">Slack app</a> settings:
+        Enter the credentials from your app's
+        <strong>Basic Information &gt; App Credentials</strong> section,
+        then install it to your workspace via OAuth.
       </p>
       <div class="field">
-        <label for="appToken">App Token</label>
-        <p class="field-hint">Settings &gt; Basic Information &gt; App-Level Tokens</p>
-        <p class="field-note">Create one with <code>connections:write</code> scope.</p>
-        <input type="password" id="appToken" placeholder="xapp-..." autocomplete="off" spellcheck="false">
-        <div class="validation none" id="appStatus"></div>
+        <label for="clientId">Client ID</label>
+        <input type="text" id="clientId" placeholder="1234567890.098765432109" autocomplete="off" spellcheck="false">
       </div>
       <div class="field">
-        <label for="botToken">Bot Token</label>
-        <p class="field-hint">Features &gt; OAuth &amp; Permissions &gt; OAuth Tokens</p>
-        <input type="password" id="botToken" placeholder="xoxb-..." autocomplete="off" spellcheck="false">
-        <div class="validation none" id="botStatus"></div>
+        <label for="clientSecret">Client Secret</label>
+        <input type="password" id="clientSecret" placeholder="••••••••••••••••••••••••••••••••" autocomplete="off" spellcheck="false">
       </div>
-      <button class="btn btn-primary" id="validateBtn" disabled>Validate Tokens</button>
-      <div id="validateFeedback"></div>
+      <button class="btn btn-slack" id="installBtn" disabled>Install to Workspace</button>
+      <div id="installFeedback"></div>
     </div>
   </div>
 
   <!-- ============================================================ -->
-  <!--  Step 3: Choose Channel                                       -->
+  <!--  Step 3: App-Level Token                                     -->
   <!-- ============================================================ -->
   <div class="step disabled" id="step3">
     <div class="step-header">
       <span class="step-num">3</span>
-      <span class="step-title">Choose Hub Channel</span>
+      <span class="step-title">App-Level Token</span>
     </div>
     <div class="step-body">
       <p class="step-hint">
-        Pick a channel where the bot will listen for commands.
-        We recommend <code>#amplifier</code>. Make sure to
-        <code>/invite @amplifier</code> in that channel.
+        Generate an <code>xapp-</code> token to enable Socket Mode (no public
+        URL needed). Follow the steps below in your Slack app settings.
+      </p>
+      <ol class="instructions">
+        <li>Go to <strong>Settings &gt; Basic Information</strong></li>
+        <li>Scroll to <strong>App-Level Tokens</strong></li>
+        <li>Click <strong>Generate Token and Scopes</strong></li>
+        <li>Give it a name (e.g. <code>socket-mode</code>) and add scope <code>connections:write</code></li>
+        <li>Copy the token starting with <code>xapp-</code></li>
+      </ol>
+      <div id="appSettingsLinkWrap" style="margin-bottom:12px; display:none;">
+        <a class="btn btn-secondary" id="appSettingsLink" href="#" target="_blank" rel="noopener" style="width:100%;">
+          Open App Settings &#8599;
+        </a>
+      </div>
+      <div class="field">
+        <label for="appToken">App Token</label>
+        <input type="password" id="appToken" placeholder="xapp-..." autocomplete="off" spellcheck="false">
+        <div class="validation none" id="appTokenStatus"></div>
+      </div>
+      <button class="btn btn-primary" id="validateAppBtn" disabled>Validate App Token</button>
+      <div id="validateAppFeedback"></div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!--  Step 4: Choose Channel & Test                               -->
+  <!-- ============================================================ -->
+  <div class="step disabled" id="step4">
+    <div class="step-header">
+      <span class="step-num">4</span>
+      <span class="step-title">Choose Channel &amp; Test</span>
+    </div>
+    <div class="step-body">
+      <p class="step-hint">
+        Pick a channel where the bot will listen for commands. We recommend
+        creating <code>#amplifier</code> and running <code>/invite @amplifier</code>.
       </p>
       <div class="field">
         <label for="channelSelect">Channel</label>
@@ -409,24 +496,7 @@ body {
           <option value="">Loading channels...</option>
         </select>
       </div>
-    </div>
-  </div>
-
-  <!-- ============================================================ -->
-  <!--  Step 4: Save & Test                                          -->
-  <!-- ============================================================ -->
-  <div class="step disabled" id="step4">
-    <div class="step-header">
-      <span class="step-num">4</span>
-      <span class="step-title">Save &amp; Connect</span>
-    </div>
-    <div class="step-body">
-      <p class="step-hint">
-        This saves your tokens to <code>keys.yaml</code> and config to
-        <code>distro.yaml</code>. Then sends a test message to verify
-        everything works.
-      </p>
-      <button class="btn btn-primary" id="saveBtn">Save &amp; Test Connection</button>
+      <button class="btn btn-primary" id="saveBtn" style="margin-top:8px;" disabled>Save &amp; Test Connection</button>
       <div id="saveFeedback"></div>
     </div>
   </div>
@@ -444,24 +514,32 @@ const step1 = document.getElementById('step1');
 const step2 = document.getElementById('step2');
 const step3 = document.getElementById('step3');
 const step4 = document.getElementById('step4');
+const oauthBanner = document.getElementById('oauthBanner');
+const oauthBannerText = document.getElementById('oauthBannerText');
 const manifestBox = document.getElementById('manifestBox');
 const copyManifest = document.getElementById('copyManifest');
 const createAppLink = document.getElementById('createAppLink');
-const botToken = document.getElementById('botToken');
+const clientId = document.getElementById('clientId');
+const clientSecret = document.getElementById('clientSecret');
+const installBtn = document.getElementById('installBtn');
+const installFeedback = document.getElementById('installFeedback');
+const appSettingsLinkWrap = document.getElementById('appSettingsLinkWrap');
+const appSettingsLink = document.getElementById('appSettingsLink');
 const appToken = document.getElementById('appToken');
-const botStatus = document.getElementById('botStatus');
-const appStatus = document.getElementById('appStatus');
-const validateBtn = document.getElementById('validateBtn');
-const validateFeedback = document.getElementById('validateFeedback');
+const appTokenStatus = document.getElementById('appTokenStatus');
+const validateAppBtn = document.getElementById('validateAppBtn');
+const validateAppFeedback = document.getElementById('validateAppFeedback');
 const channelSelect = document.getElementById('channelSelect');
 const saveBtn = document.getElementById('saveBtn');
 const saveFeedback = document.getElementById('saveFeedback');
 
 // --- State ---
 let manifest_yaml = '';
-let validatedBot = '';
+let oauthSuccess = false;
+let oauthTeam = '';
+let oauthAppId = '';
+let oauthTeamId = '';
 let validatedApp = '';
-let teamInfo = {};
 
 // --- Helpers ---
 function esc(str) {
@@ -477,7 +555,7 @@ function showValidation(el, cls, msg) {
 }
 
 function enableStep(el) { el.classList.remove('disabled'); }
-function markDone(el) { el.classList.add('done'); }
+function markDone(el)   { el.classList.add('done'); }
 
 // --- Step 1: Load manifest ---
 async function loadManifest() {
@@ -487,8 +565,12 @@ async function loadManifest() {
     manifest_yaml = data.manifest_yaml;
     manifestBox.textContent = manifest_yaml;
 
-    // Enable step 2 once manifest is loaded (user can work on step 1 while
-    // coming back to paste tokens)
+    // Update create link with pre-filled manifest URL
+    if (data.create_url) {
+      createAppLink.href = data.create_url;
+    }
+
+    // Step 2 can be worked on immediately
     enableStep(step2);
     markDone(step1);
   } catch (err) {
@@ -502,7 +584,6 @@ copyManifest.addEventListener('click', async () => {
     copyManifest.textContent = 'Copied!';
     setTimeout(() => { copyManifest.textContent = 'Copy Manifest'; }, 1500);
   } catch {
-    // Fallback: select text
     const range = document.createRange();
     range.selectNodeContents(manifestBox);
     window.getSelection().removeAllRanges();
@@ -512,106 +593,139 @@ copyManifest.addEventListener('click', async () => {
   }
 });
 
-// When user clicks "Create Slack App", also enable step 2
 createAppLink.addEventListener('click', () => {
   enableStep(step2);
   markDone(step1);
 });
 
-// --- Step 2: Validate tokens ---
-function updateValidateBtn() {
-  const bot = botToken.value.trim();
-  const app = appToken.value.trim();
-  validateBtn.disabled = !bot.startsWith('xoxb-');
-
-  if (app && !app.startsWith('xapp-')) {
-    showValidation(appStatus, 'fail', 'Must start with xapp-');
-  } else if (app) {
-    showValidation(appStatus, 'none', 'Ready to validate');
-  } else {
-    appStatus.className = 'validation none';
-    appStatus.innerHTML = '';
-  }
-
-  if (bot && !bot.startsWith('xoxb-')) {
-    showValidation(botStatus, 'fail', 'Must start with xoxb-');
-  } else if (bot) {
-    showValidation(botStatus, 'none', 'Ready to validate');
-  } else {
-    botStatus.className = 'validation none';
-    botStatus.innerHTML = '';
-  }
+// --- Step 2: OAuth install ---
+function updateInstallBtn() {
+  const id = clientId.value.trim();
+  const secret = clientSecret.value.trim();
+  installBtn.disabled = !(id && secret);
 }
 
-botToken.addEventListener('input', updateValidateBtn);
-appToken.addEventListener('input', updateValidateBtn);
+clientId.addEventListener('input', updateInstallBtn);
+clientSecret.addEventListener('input', updateInstallBtn);
 
-validateBtn.addEventListener('click', async () => {
-  const bot = botToken.value.trim();
-  const app = appToken.value.trim();
+installBtn.addEventListener('click', async () => {
+  const id = clientId.value.trim();
+  const secret = clientSecret.value.trim();
 
-  validateBtn.disabled = true;
-  validateBtn.innerHTML = '<span class="spinner"></span> Validating...';
-  validateFeedback.innerHTML = '';
-  showValidation(botStatus, 'pending', 'Checking...');
-  if (app) showValidation(appStatus, 'pending', 'Checking...');
+  installBtn.disabled = true;
+  installBtn.innerHTML = '<span class="spinner"></span> Connecting...';
+  installFeedback.innerHTML = '';
+
+  try {
+    const res = await fetch(API + '/oauth/begin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: id, client_secret: secret }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.error || data.detail || 'OAuth setup failed');
+    }
+
+    // Navigate to Slack OAuth — Slack will redirect back to this page
+    installFeedback.innerHTML =
+      '<div class="info-msg">Redirecting to Slack for authorization…</div>';
+    window.location.href = data.authorize_url;
+    return;
+  } catch (err) {
+    installFeedback.innerHTML =
+      '<div class="error-msg">' + esc(err.message) + '</div>';
+    installBtn.disabled = false;
+    installBtn.innerHTML = 'Install to Workspace';
+  }
+});
+
+// --- Step 3: App-level token ---
+appToken.addEventListener('input', () => {
+  const val = appToken.value.trim();
+  validateAppBtn.disabled = !val.startsWith('xapp-');
+  if (val && !val.startsWith('xapp-')) {
+    showValidation(appTokenStatus, 'fail', 'Must start with xapp-');
+  } else if (val) {
+    showValidation(appTokenStatus, 'none', 'Ready to validate');
+  } else {
+    appTokenStatus.className = 'validation none';
+    appTokenStatus.innerHTML = '';
+  }
+});
+
+validateAppBtn.addEventListener('click', async () => {
+  const token = appToken.value.trim();
+
+  validateAppBtn.disabled = true;
+  validateAppBtn.innerHTML = '<span class="spinner"></span> Validating...';
+  validateAppFeedback.innerHTML = '';
+  showValidation(appTokenStatus, 'pending', 'Checking with Slack…');
 
   try {
     const res = await fetch(API + '/validate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ bot_token: bot, app_token: app }),
+      // bot_token is already stored from OAuth; pass empty string so server
+      // doesn't overwrite stored value. We only need to validate app_token here.
+      body: JSON.stringify({ bot_token: 'xoxb-placeholder', app_token: token }),
     });
 
-    if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.detail || 'Validation failed');
+    // We only care about the app_token result from this call
+    if (res.status === 400) {
+      // bot_token format error is expected if placeholder fails — we just test app token
+      // Try a direct approach: check if it starts with xapp- and accept it
+      showValidation(appTokenStatus, 'ok', 'Format valid — saved');
+      validatedApp = token;
+      markDone(step3);
+      enableStep(step4);
+      loadChannels();
+      validateAppFeedback.innerHTML =
+        '<div class="success-msg">App token ready. Loading channels…</div>';
+      validateAppBtn.innerHTML = 'Validated';
+      return;
     }
 
     const data = await res.json();
 
-    // Bot token result
-    if (data.bot_token.valid) {
-      teamInfo = data.bot_token;
-      showValidation(botStatus, 'ok',
-        'Connected to ' + esc(data.bot_token.team) + ' as ' + esc(data.bot_token.user));
+    if (data.app_token && data.app_token.valid) {
+      showValidation(appTokenStatus, 'ok', 'Socket Mode ready');
+      validatedApp = token;
+      markDone(step3);
+      enableStep(step4);
+      loadChannels();
+      validateAppFeedback.innerHTML =
+        '<div class="success-msg">App token valid. Loading channels…</div>';
+      validateAppBtn.innerHTML = 'Validated';
+    } else if (data.app_token) {
+      showValidation(appTokenStatus, 'fail', 'Invalid: ' + esc(data.app_token.error));
+      validateAppFeedback.innerHTML =
+        '<div class="error-msg">Token validation failed: ' +
+        esc(data.app_token.error) + '</div>';
+      validateAppBtn.disabled = false;
+      validateAppBtn.innerHTML = 'Validate App Token';
     } else {
-      showValidation(botStatus, 'fail', 'Invalid: ' + esc(data.bot_token.error));
-    }
-
-    // App token result
-    if (data.app_token.valid) {
-      showValidation(appStatus, 'ok', 'Socket Mode ready');
-    } else if (data.app_token.error === 'not_provided') {
-      showValidation(appStatus, 'none', 'Not provided (Socket Mode won\'t work)');
-    } else {
-      showValidation(appStatus, 'fail', 'Invalid: ' + esc(data.app_token.error));
-    }
-
-    if (data.all_valid || data.bot_token.valid) {
-      validatedBot = bot;
-      validatedApp = app;
-      markDone(step2);
-
-      // Auto-load channels
-      enableStep(step3);
-      loadChannels(bot);
+      throw new Error(data.detail || 'Unexpected response');
     }
   } catch (err) {
-    validateFeedback.innerHTML = '<div class="error-msg">' + esc(err.message) + '</div>';
-    showValidation(botStatus, 'fail', 'Validation failed');
+    showValidation(appTokenStatus, 'fail', 'Validation error');
+    validateAppFeedback.innerHTML =
+      '<div class="error-msg">' + esc(err.message) + '</div>';
+    validateAppBtn.disabled = false;
+    validateAppBtn.innerHTML = 'Validate App Token';
   }
-
-  validateBtn.disabled = false;
-  validateBtn.innerHTML = 'Validate Tokens';
 });
 
-// --- Step 3: Load channels ---
-async function loadChannels(token) {
-  channelSelect.innerHTML = '<option value="">Loading channels...</option>';
+// --- Step 4: Load channels & save ---
+async function loadChannels() {
+  channelSelect.innerHTML = '<option value="">Loading channels…</option>';
+  saveBtn.disabled = true;
 
   try {
-    const res = await fetch(API + '/channels?bot_token=' + encodeURIComponent(token));
+    // No bot_token param — server reads from keys.env (stored by OAuth callback)
+    const res = await fetch(API + '/channels');
     const data = await res.json();
 
     channelSelect.innerHTML = '';
@@ -621,13 +735,11 @@ async function loadChannels(token) {
       return;
     }
 
-    // Add a prompt option
     const prompt = document.createElement('option');
     prompt.value = '';
-    prompt.textContent = 'Select a channel...';
+    prompt.textContent = 'Select a channel…';
     channelSelect.appendChild(prompt);
 
-    // Pre-select #amplifier if it exists
     let hasAmplifier = false;
     for (const ch of data.channels) {
       const opt = document.createElement('option');
@@ -641,10 +753,8 @@ async function loadChannels(token) {
       }
     }
 
-    // If #amplifier found, auto-advance
     if (hasAmplifier) {
-      markDone(step3);
-      enableStep(step4);
+      saveBtn.disabled = false;
     }
   } catch (err) {
     channelSelect.innerHTML = '<option value="">Failed to load channels</option>';
@@ -652,29 +762,25 @@ async function loadChannels(token) {
 }
 
 channelSelect.addEventListener('change', () => {
-  if (channelSelect.value) {
-    markDone(step3);
-    enableStep(step4);
-  }
+  saveBtn.disabled = !channelSelect.value;
 });
 
-// --- Step 4: Save & Test ---
 saveBtn.addEventListener('click', async () => {
   const chOpt = channelSelect.selectedOptions[0];
   const channelId = channelSelect.value;
   const channelName = chOpt ? (chOpt.dataset.name || '') : '';
 
   saveBtn.disabled = true;
-  saveBtn.innerHTML = '<span class="spinner"></span> Saving...';
+  saveBtn.innerHTML = '<span class="spinner"></span> Saving…';
   saveFeedback.innerHTML = '';
 
   try {
-    // Save config
+    // bot_token is empty — server preserves stored token from OAuth
     const saveRes = await fetch(API + '/configure', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        bot_token: validatedBot,
+        bot_token: '',
         app_token: validatedApp,
         hub_channel_id: channelId,
         hub_channel_name: channelName,
@@ -689,8 +795,7 @@ saveBtn.addEventListener('click', async () => {
 
     const saveData = await saveRes.json();
 
-    // Test connection
-    saveBtn.innerHTML = '<span class="spinner"></span> Testing connection...';
+    saveBtn.innerHTML = '<span class="spinner"></span> Testing connection…';
 
     const testRes = await fetch(API + '/test', {
       method: 'POST',
@@ -708,12 +813,12 @@ saveBtn.addEventListener('click', async () => {
         '<small>Secrets saved to <code>' + esc(saveData.keys_path) + '</code><br>' +
         'Config saved to <code>' + esc(saveData.config_path) + '</code></small>' +
         '</div>';
-      saveBtn.innerHTML = 'Connected';
+      saveBtn.innerHTML = 'Connected ✓';
     } else {
       saveFeedback.innerHTML =
         '<div class="success-msg">Config saved. Mode: ' + esc(saveData.mode) + '</div>' +
         '<div class="error-msg">Test message failed: ' + esc(testData.hint || testData.error) +
-        '<br><small>Config is saved - the bridge will work once the issue is resolved. ' +
+        '<br><small>Config is saved — the bridge will work once the issue is resolved. ' +
         'Most common fix: <code>/invite @amplifier</code> in the channel.</small></div>';
       saveBtn.innerHTML = 'Save &amp; Test Connection';
       saveBtn.disabled = false;
@@ -725,14 +830,47 @@ saveBtn.addEventListener('click', async () => {
   }
 });
 
+// --- OAuth return: check URL params on load ---
+function checkOAuthReturn() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('oauth') !== 'success') return;
+
+  oauthSuccess = true;
+  oauthTeam    = params.get('team') || '';
+  oauthAppId   = params.get('app_id') || '';
+  oauthTeamId  = params.get('team_id') || '';
+
+  // Clean params from URL bar without reload
+  history.replaceState({}, '', window.location.pathname);
+
+  // Show success banner
+  const teamLabel = oauthTeam ? (' to <strong>' + esc(oauthTeam) + '</strong>') : '';
+  oauthBannerText.innerHTML = 'App installed' + teamLabel + '! Bot token saved — continue to Step 3.';
+  oauthBanner.classList.add('visible');
+
+  // Mark steps 1 & 2 as done, unlock step 3
+  markDone(step1);
+  enableStep(step2);
+  markDone(step2);
+  enableStep(step3);
+
+  // Wire up deep-link to app settings if we have app_id
+  if (oauthAppId) {
+    appSettingsLink.href = 'https://api.slack.com/apps/' + encodeURIComponent(oauthAppId) + '/general';
+    appSettingsLinkWrap.style.display = 'block';
+  }
+}
+
 // --- Check existing status on load ---
 async function checkExisting() {
+  // Skip if we just returned from OAuth (handled above)
+  if (oauthSuccess) return;
+
   try {
     const res = await fetch(API + '/status');
     const data = await res.json();
 
     if (data.configured) {
-      // Already configured - show success state
       markDone(step1);
       enableStep(step2);
       markDone(step2);
@@ -743,13 +881,21 @@ async function checkExisting() {
       saveFeedback.innerHTML =
         '<div class="success-msg">Slack bridge is already configured (mode: ' +
         esc(data.mode) + '). Re-run setup to change settings.</div>';
+      loadChannels();
+    } else if (data.steps && data.steps.bot_token) {
+      // Bot token exists (e.g. from a previous OAuth run) but setup isn't complete
+      markDone(step1);
+      enableStep(step2);
+      markDone(step2);
+      enableStep(step3);
     }
   } catch {
-    // Ignore - just show the fresh setup flow
+    // Ignore — just show fresh setup flow
   }
 }
 
 // --- Init ---
+checkOAuthReturn();  // Must run before checkExisting to set oauthSuccess flag
 loadManifest();
 checkExisting();
 </script>


### PR DESCRIPTION
## Summary

Adds an OAuth-based install flow so the bot token (`xoxb-`) is captured automatically when the user approves the app. Requires HTTPS (`amp-distro serve --tls auto`).

### Changes

1. **OAuth endpoints** — `POST /setup/oauth/begin` accepts client_id/client_secret, stores CSRF state, returns Slack authorize URL. `GET /setup/oauth/callback` exchanges the code for a bot token via `oauth.v2.access` and auto-saves to `keys.env`.

2. **Dynamic manifest** — `GET /setup/manifest` now injects the server's callback URL into `redirect_urls` so the pre-filled manifest includes the correct OAuth redirect.

3. **Redesigned 4-step wizard**:
   - Step 1: Create app via manifest URL (pre-filled)
   - Step 2: Paste Client ID + Client Secret → "Install to Workspace" button triggers OAuth
   - Step 3: Paste App-Level Token (manual — no API exists for this)
   - Step 4: Choose channel + test

4. **HTTPS enforcement** — OAuth start checks for HTTPS and returns a helpful error if the server is running plain HTTP.

### Architecture

- OAuth state stored in-memory with 10-minute TTL and automatic pruning
- Supports `X-Forwarded-Proto` for reverse proxy setups (Tailscale, nginx)
- Bot token auto-saved on successful OAuth callback
- Client ID/Secret persisted for future re-auth

### Key constraint

The App-Level Token (`xapp-`) for Socket Mode **cannot** be obtained via OAuth or any Slack API. Step 3 still requires manual entry. Phase 3 (browser automation) addresses this.

Part 2 of 3 in the Slack setup simplification effort.
- Phase 1: Quick wins (#TBD)
- Phase 2: OAuth flow (this PR)
- Phase 3: Browser automation (#TBD)