### PR TITLE
fix: resolve stale amplifierd source path in distro-service

### DIFF
--- a/distro-service/pyproject.toml
+++ b/distro-service/pyproject.toml
@@ -19,7 +19,7 @@ amp-distro = "amplifier_distro.cli:main"
 
 # Local dev overrides: use sibling checkouts instead of git URLs
 [tool.uv.sources]
-amplifierd = { path = "../../amplifierd", editable = true }
+amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
 amplifierd-plugin-distro = { path = "../amplifierd-plugins/amplifierd-plugin-distro", editable = true }
 amplifierd-plugin-slack = { path = "../amplifierd-plugins/amplifierd-plugin-slack", editable = true }
 # amplifierd-plugin-voice — now a proper remote dep, no local override needed

--- a/distro-service/uv.lock
+++ b/distro-service/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -18,7 +18,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "amplifierd", editable = "../../amplifierd" },
+    { name = "amplifierd", git = "https://github.com/microsoft/amplifierd?branch=main" },
     { name = "amplifierd-plugin-auth", editable = "../amplifierd-plugins/amplifierd-plugin-auth" },
     { name = "amplifierd-plugin-chat", git = "https://github.com/payneio/amplifierd-plugin-chat?rev=main" },
     { name = "amplifierd-plugin-distro", editable = "../amplifierd-plugins/amplifierd-plugin-distro" },
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "amplifierd"
 version = "0.1.0"
-source = { editable = "../../amplifierd" }
+source = { git = "https://github.com/microsoft/amplifierd?branch=main#158c2fe3c4214142092bb90216633b018fb8d33e" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },
@@ -80,26 +80,6 @@ dependencies = [
     { name = "sse-starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "amplifier-core", specifier = ">=1.1.1" },
-    { name = "amplifier-foundation", git = "https://github.com/microsoft/amplifier-foundation" },
-    { name = "click", specifier = ">=8.1.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
-    { name = "pydantic", specifier = ">=2.10.0" },
-    { name = "pydantic-settings", specifier = ">=2.6.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.407" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.10" },
-    { name = "sse-starlette", specifier = ">=2.2.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "amplifierd-plugin-auth"


### PR DESCRIPTION
The [tool.uv.sources] override for amplifierd had a stale local path (../../amplifierd) that pointed outside the monorepo, causing `uv sync` to fail with "Distribution not found". Changed it to use the git source (https://github.com/microsoft/amplifierd, branch main) so uv resolves correctly.