### PR TITLE
chore: update amplifierd lockfile to latest main (provider fixes)

### DIFF
--- a/distro-service/uv.lock
+++ b/distro-service/uv.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "amplifierd"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifierd?branch=main#158c2fe3c4214142092bb90216633b018fb8d33e" }
+source = { git = "https://github.com/microsoft/amplifierd?branch=main#d8ae8e28d51aa63dfcac08782e53d0638c45adb6" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },


### PR DESCRIPTION
## Summary

- Updates `distro-service/uv.lock` to pin `amplifierd` to latest main (`d8ae8e28`, from `158c2fe3`)
- Picks up three provider fixes merged into amplifierd:
  - **PR #8**: Fix provider merge/registration issue
  - **PR #11**: Install-state handling fix
  - **PR #14**: `keys.env` loading fix
- Also includes associated security layer changes from amplifierd main

## Test plan
- [ ] Verify `distro-service` resolves and installs correctly with updated lockfile
- [ ] Confirm provider functionality works end-to-end with the three fixes in place

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)