### PR TITLE
fix: prevent SessionAuthMiddleware from activating in localhost mode

### DIFF
--- a/distro-service/src/amplifier_distro/cli.py
+++ b/distro-service/src/amplifier_distro/cli.py
@@ -122,6 +122,7 @@ def serve(
         reload=reload,
         log_level=log_level,
         home_redirect="/distro/",  # Enable distro dashboard
+        auth_by_default=True,
     )
 
 
@@ -135,6 +136,8 @@ def _start_server(
     reload: bool,
     log_level: str | None,
     home_redirect: str | None,
+    *,
+    auth_by_default: bool = False,
 ) -> None:
     """Common server startup logic."""
     # --ssl-certfile implies manual TLS mode when tls_mode is still default
@@ -149,10 +152,10 @@ def _start_server(
 
     os.environ.setdefault("AMPLIFIERD_TLS_MODE", tls_mode)
 
-    if not no_auth:
-        os.environ.setdefault("AMPLIFIERD_AUTH_ENABLED", "true")
-    else:
+    if no_auth:
         os.environ["AMPLIFIERD_AUTH_ENABLED"] = "false"
+    elif auth_by_default:
+        os.environ.setdefault("AMPLIFIERD_AUTH_ENABLED", "true")
 
     # Delegate to amplifierd's serve command
     from amplifierd.cli import serve as amplifierd_serve


### PR DESCRIPTION
## Summary
- Fixed SessionAuthMiddleware activating unconditionally in localhost mode, causing warnings on non-Linux platforms
- Added `auth_by_default` parameter to `_start_server()` for conditional auth enablement
- Only `amp-distro serve` now enables auth by default; localhost mode leaves it disabled

## Problem
When running `amp-distro` in localhost mode (no subcommand), the `_start_server()` function unconditionally set `AMPLIFIERD_AUTH_ENABLED=true` whenever `--no-auth` wasn't passed. This caused `SessionAuthMiddleware` to register in the amplifierd daemon. On macOS (and any non-Linux platform), the PAM auth plugin correctly skips activation, but the already-registered middleware finds no `auth_verify_session` callable and logs a warning on every request:

```
WARNING [amplifierd.security.middleware] SessionAuthMiddleware active but auth_verify_session not set (auth plugin may not have loaded); passing request through
```

Auth should only be enabled by default in remote/serve mode (`amp-distro serve`), not localhost mode.

## Solution
Added an `auth_by_default` keyword-only parameter to `_start_server()`, defaulting to `False`. Only `serve()` passes `auth_by_default=True`. The new behavior:
- `--no-auth` explicitly forces `AMPLIFIERD_AUTH_ENABLED=false` (either mode)
- `auth_by_default=True` (serve mode only) sets `AMPLIFIERD_AUTH_ENABLED=true`
- Otherwise (localhost mode) the env var is left unset, so `DaemonSettings.auth_enabled` stays at its default (`False`)

## Notes
Running `amp-distro serve` on macOS will still produce the warning since PAM is Linux-only and the plugin won't set `auth_verify_session`. This is expected per the design doc (macOS PAM is deferred). A future improvement could add a localhost bypass to `SessionAuthMiddleware` itself, similar to what `ApiKeyMiddleware` already has.

## Test plan
- [x] Implementation committed to branch
- [ ] Verify localhost mode doesn't enable auth
- [ ] Verify serve mode enables auth appropriately
- [ ] Verify `--no-auth` overrides defaults