### PR TITLE
fix(distro-plugin): loading screen follows system theme

### DIFF
--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/loading.html
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/loading.html
@@ -4,23 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Amplifier — Starting up</title>
+<script src="/static/theme-init.js"></script>
+<link rel="stylesheet" href="/static/amplifier-theme.css">
 <style>
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-html, body {
-  height: 100%;
-  -webkit-font-smoothing: antialiased;
-}
-
 body {
   display: flex;
   align-items: center;
   justify-content: center;
   min-height: 100%;
-  background: #171717;
-  color: #FAFAFA;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-               Helvetica, Arial, sans-serif;
 }
 
 .stage {
@@ -34,7 +25,7 @@ body {
 .wordmark {
   font-size: clamp(2.5rem, 8vw, 3.5rem);
   font-weight: 700;
-  color: #7B6FF0;
+  color: var(--signal);
   letter-spacing: -0.04em;
   line-height: 1;
   margin-bottom: 32px;
@@ -59,7 +50,7 @@ body {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #7B6FF0;
+  background: var(--signal);
   animation: dotBounce 1.4s ease-in-out infinite;
 }
 .dot:nth-child(2) { animation-delay: 0.16s; }
@@ -73,7 +64,7 @@ body {
 /* Status text */
 .status-msg {
   font-size: 14px;
-  color: #A3A3A3;
+  color: var(--ink-slate);
   line-height: 1.5;
   min-height: 1.5em;
 }
@@ -83,16 +74,16 @@ body {
   display: none;
   margin-top: 28px;
   padding: 16px 20px;
-  background: #262626;
-  border: 1px solid #333333;
+  background: var(--canvas-stone);
+  border: 1px solid var(--canvas-mist);
   border-radius: 12px;
   font-size: 13px;
-  color: #A3A3A3;
+  color: var(--ink-slate);
   line-height: 1.5;
 }
 
 .slow-msg a {
-  color: #7B6FF0;
+  color: var(--signal);
   text-decoration: none;
   font-weight: 500;
 }
@@ -103,11 +94,11 @@ body {
   display: none;
   margin-top: 28px;
   padding: 16px 20px;
-  background: rgba(248, 113, 113, 0.08);
+  background: var(--error-soft);
   border: 1px solid rgba(248, 113, 113, 0.3);
   border-radius: 12px;
   font-size: 13px;
-  color: #F87171;
+  color: var(--error);
   line-height: 1.5;
 }
 
@@ -117,15 +108,15 @@ body {
   font-family: inherit;
   font-size: 13px;
   font-weight: 600;
-  color: #FAFAFA;
-  background: #333333;
+  color: var(--ink);
+  background: var(--canvas-mist);
   border: none;
   border-radius: 8px;
   padding: 8px 18px;
   cursor: pointer;
   transition: background 0.15s;
 }
-.retry-btn:hover { background: #404040; }
+.retry-btn:hover { background: var(--canvas-stone); }
 
 @media (prefers-reduced-motion: reduce) {
   .wordmark { animation: none; }


### PR DESCRIPTION
## Summary

- Loading screen was using hardcoded dark-mode colors, ignoring the shared theme system
- Adds `theme-init.js` and `amplifier-theme.css` imports
- Replaces ~12 hex literals with CSS variables so the loading screen respects light/dark mode via `prefers-color-scheme`, matching all other pages

## Test plan

- [ ] Verify loading screen renders correctly in light mode
- [ ] Verify loading screen renders correctly in dark mode
- [ ] Verify `prefers-color-scheme` media query triggers correct theme on system theme change

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)