### PR TITLE
fix: disable auth widget and memory API probes when PAM is inactive

### DIFF
--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/routes.py
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/routes.py
@@ -94,6 +94,7 @@ class DistroSettingsUpdate(BaseModel):
     section: str | None = None
     values: dict[str, Any] = {}
 
+
 # Candidate directory names to scan under $HOME for workspace detection.
 _WORKSPACE_CANDIDATES = ("projects", "repos", "src", "code", "dev", "workspace")
 
@@ -117,6 +118,7 @@ def compute_phase(settings: DistroPluginSettings) -> str:
             return "ready"
 
     return "detected"
+
 
 def _get_current_provider(settings: DistroPluginSettings) -> dict[str, Any] | None:
     """Return the current primary provider info by matching overlay URIs."""
@@ -726,6 +728,12 @@ def create_routes() -> APIRouter:
         html_path = _STATIC_DIR / "dashboard.html"
         try:
             content = html_path.read_text()
+            # Tell the frontend whether PAM auth is active so the auth
+            # widget can skip its /auth/me probe when there is no session
+            # infrastructure to query.
+            auth_on = hasattr(request.app.state, "auth_verify_session")
+            tag = f"<script>window.__AUTH_ENABLED={str(auth_on).lower()}</script>"
+            content = content.replace("</head>", tag + "</head>", 1)
             return HTMLResponse(content=content)
         except OSError:
             return HTMLResponse(
@@ -752,6 +760,12 @@ def create_routes() -> APIRouter:
         html_path = _STATIC_DIR / "settings.html"
         try:
             content = html_path.read_text()
+            # Tell the frontend whether PAM auth is active so the auth
+            # widget can skip its /auth/me probe when there is no session
+            # infrastructure to query.
+            auth_on = hasattr(request.app.state, "auth_verify_session")
+            tag = f"<script>window.__AUTH_ENABLED={str(auth_on).lower()}</script>"
+            content = content.replace("</head>", tag + "</head>", 1)
             return HTMLResponse(content=content)
         except OSError:
             return HTMLResponse(

--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/auth-widget.js
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/auth-widget.js
@@ -88,6 +88,10 @@
     var container = opts.container;
     if (!container) return;
 
+    // When PAM auth is not active the server sets __AUTH_ENABLED = false.
+    // Skip the /auth/me probe entirely — there is no session infrastructure.
+    if (!window.__AUTH_ENABLED) return;
+
     injectStyle();
 
     fetch('/auth/me')

--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/settings.html
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/settings.html
@@ -872,8 +872,11 @@ async function loadAll() {
     api('GET', '/preflight'),
     fetch('/distro/detect').then(r => r.ok ? r.json() : { error: 'HTTP ' + r.status }).catch(() => ({ error: true })),
     api('GET', '/distro-settings'),
-    coreApi('GET', '/memory/stats').catch(() => ({ error: true })),
-    coreApi('GET', '/memory/work-status'),
+    // TODO: restore when amplifierd exposes /api/memory/* routes.
+    // coreApi('GET', '/memory/stats').catch(() => ({ error: true })),
+    // coreApi('GET', '/memory/work-status'),
+    Promise.resolve({ error: true }),
+    Promise.resolve({ error: true }),
     api('GET', '/preflight'),
     api('GET', '/providers'),
   ]);


### PR DESCRIPTION
## Summary

PR #205 added a stub `/auth/me` endpoint that returned 401 when the auth plugin was inactive. That was the wrong approach — when PAM is off, the auth widget should not probe at all. There is no user session, no login, no sign-out; the entire concept of `/auth/me` is meaningless without PAM.

This PR fixes it properly by making the server tell the frontend whether auth is active, eliminating all unnecessary network requests.

## Changes

### Server-side flag injection (`distro_plugin/routes.py`)
When the distro plugin serves `dashboard.html` or `settings.html`, it checks `hasattr(request.app.state, "auth_verify_session")` — that attribute only exists when the auth plugin has actually activated PAM. It injects `<script>window.__AUTH_ENABLED=true|false</script>` into the HTML `<head>` before returning the page.

### Client-side guard (`distro_plugin/static/auth-widget.js`)
The very first thing `init()` does is `if (!window.__AUTH_ENABLED) return;`. When PAM is off, the widget exits immediately — no style injection, no `fetch("/auth/me")`, zero network requests, zero console output.

### Revert the /auth/me stub (`auth_plugin/__init__.py`)
The stub endpoint from #205 is removed. The auth plugin returns a clean empty router when inactive, as originally designed.

### Disable unimplemented memory API calls (`distro_plugin/static/settings.html`)
`settings.html` was calling `/api/memory/stats` and `/api/memory/work-status` — endpoints with no backend implementation anywhere. These calls are disabled to eliminate additional 404 noise.

## Result

When PAM is off, the console is completely clean — no 404s, no 401s, no probing requests at all.