### PR TITLE
chore: update amplifierd-plugin-chat repo URL after rename to amplifier-chat

### DIFF
--- a/distro-service/pyproject.toml
+++ b/distro-service/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "amplifierd @ git+https://github.com/microsoft/amplifierd@main",
     "amplifierd-plugin-distro @ git+https://github.com/microsoft/amplifierd@main#subdirectory=amplifierd-plugins/distro",
-    "amplifierd-plugin-chat @ git+https://github.com/microsoft/amplifierd-plugin-chat@main",
+    "amplifierd-plugin-chat @ git+https://github.com/microsoft/amplifier-chat@main",
     "amplifierd-plugin-slack @ git+https://github.com/microsoft/amplifierd@main#subdirectory=amplifierd-plugins/slack",
     "amplifierd-plugin-voice @ git+https://github.com/microsoft/amplifier-voice@main",
     "amplifierd-plugin-auth",
@@ -24,7 +24,7 @@ amplifierd-plugin-distro = { path = "../amplifierd-plugins/amplifierd-plugin-dis
 amplifierd-plugin-slack = { path = "../amplifierd-plugins/amplifierd-plugin-slack", editable = true }
 # amplifierd-plugin-voice — now a proper remote dep, no local override needed
 amplifierd-plugin-auth = { path = "../amplifierd-plugins/amplifierd-plugin-auth", editable = true }
-# amplifierd-plugin-chat = { path = "../../amplifierd-plugin-chat", editable = true }
+# amplifierd-plugin-chat = { path = "../../amplifier-chat", editable = true }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/distro-service/uv.lock
+++ b/distro-service/uv.lock
@@ -20,7 +20,7 @@ dependencies = [
 requires-dist = [
     { name = "amplifierd", git = "https://github.com/microsoft/amplifierd?branch=main" },
     { name = "amplifierd-plugin-auth", editable = "../amplifierd-plugins/amplifierd-plugin-auth" },
-    { name = "amplifierd-plugin-chat", git = "https://github.com/microsoft/amplifierd-plugin-chat?rev=main" },
+    { name = "amplifierd-plugin-chat", git = "https://github.com/microsoft/amplifier-chat?rev=main" },
     { name = "amplifierd-plugin-distro", editable = "../amplifierd-plugins/amplifierd-plugin-distro" },
     { name = "amplifierd-plugin-slack", editable = "../amplifierd-plugins/amplifierd-plugin-slack" },
     { name = "amplifierd-plugin-voice", git = "https://github.com/microsoft/amplifier-voice?rev=main" },
@@ -108,7 +108,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "amplifierd-plugin-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifierd-plugin-chat?rev=main#a918af23adfe4f099d6e81cfb7b755078204745a" }
+source = { git = "https://github.com/microsoft/amplifier-chat?rev=main#cc32e18aacdac007253effef890e161160df211d" }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },

--- a/docs/plans/2026-03-10-bundle-prewarm-design.md
+++ b/docs/plans/2026-03-10-bundle-prewarm-design.md
@@ -14,7 +14,7 @@
 
 **Repos NOT touched:**
 - `amplifier-foundation` — use public API only (`registry.update()` for cache invalidation)
-- `amplifierd-plugin-chat` — consumer only; 503 route guard in amplifierd handles it
+- `amplifier-chat` — consumer only; 503 route guard in amplifierd handles it
 
 ---
 


### PR DESCRIPTION
## Summary

- The GitHub repo `microsoft/amplifierd-plugin-chat` was renamed to `microsoft/amplifier-chat`
- Updated the git URL in `distro-service/pyproject.toml` (package name `amplifierd-plugin-chat` is unchanged — only the URL changed)
- Regenerated `distro-service/uv.lock` to pick up the new repo URL/commit hash
- Updated the reference in `docs/plans/2026-03-10-bundle-prewarm-design.md`

## Test plan
- [x] `uv lock` resolved cleanly against the new repo URL
- [x] No functional code changes — URL rename only

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)