### PR TITLE
chore: bump amplifier-chat to 1e8121e

### DIFF
--- a/distro-service/uv.lock
+++ b/distro-service/uv.lock
@@ -30,7 +30,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?rev=main#99f4e0f25fd95bd6297c1f08047b9ee8b16674ab" }
+source = { git = "https://github.com/microsoft/amplifier-chat?rev=main#1e8121ef893b19f86d8a81a6380657a9fccb2337" }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },


### PR DESCRIPTION
Bumps `amplifier-chat` lock from `99f4e0f` to `1e8121e` to pick up microsoft/amplifier-chat#20:

**fix: register overlay bundle when chat runs standalone**

When `amplifier-chat` runs standalone (without the distro plugin), the user's overlay bundle at `~/.amplifier-distro/bundle/` was not registered in the bundle_registry before prewarm. This caused amplifierd to prewarm the raw upstream bundle instead of the user's customized one, resulting in 502/503 errors on session creation and resume.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)