### PR TITLE
fix: resolve CI pipeline failures — lint, pyright, and workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Type check
         working-directory: distro-service
-        run: uvx pyright src/
+        run: uv run --with pyright pyright src/
 
   service:
     name: Service Boot

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 14 * * *" # Daily 6am PT (14:00 UTC)
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     name: Update & Test

--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/distro_settings.py
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/distro_settings.py
@@ -104,6 +104,22 @@ class WatchdogSettings:
 
 
 @dataclass
+class TlsSettings:
+    """TLS configuration for the distro server."""
+
+    mode: str = "off"
+    certfile: str = ""
+    keyfile: str = ""
+
+
+@dataclass
+class ServerSettings:
+    """Server runtime configuration."""
+
+    tls: TlsSettings = field(default_factory=TlsSettings)
+
+
+@dataclass
 class DistroSettings:
     """Root settings object for the distro experience layer."""
 
@@ -113,6 +129,7 @@ class DistroSettings:
     slack: SlackSettings = field(default_factory=SlackSettings)
     voice: VoiceSettings = field(default_factory=VoiceSettings)
     watchdog: WatchdogSettings = field(default_factory=WatchdogSettings)
+    server: ServerSettings = field(default_factory=ServerSettings)
 
 
 # ---------------------------------------------------------------------------

--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/routes.py
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/routes.py
@@ -12,7 +12,7 @@ import logging
 import os
 import platform
 import shutil
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, TypedDict
 

--- a/distro-service/src/amplifier_distro/distro_settings.py
+++ b/distro-service/src/amplifier_distro/distro_settings.py
@@ -1,0 +1,17 @@
+"""Zero-arg distro settings loader for distro-service convenience.
+
+Wraps ``distro_plugin.distro_settings.load()`` so callers inside
+``amplifier_distro`` (e.g. ``doctor.py``) can call ``load_settings()``
+without constructing a ``DistroPluginSettings`` instance each time.
+"""
+
+from __future__ import annotations
+
+from distro_plugin.config import DistroPluginSettings
+from distro_plugin.distro_settings import DistroSettings as DistroSettings
+from distro_plugin.distro_settings import load as _load
+
+
+def load() -> DistroSettings:
+    """Load distro settings using default DistroPluginSettings."""
+    return _load(DistroPluginSettings())

--- a/distro-service/src/amplifier_distro/doctor.py
+++ b/distro-service/src/amplifier_distro/doctor.py
@@ -24,7 +24,8 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, Field
 
-from . import conventions, tailscale
+from . import conventions
+from amplifierd.security import tailscale
 from .distro_settings import load as load_settings
 from .server.daemon import is_running, read_pid
 

--- a/distro-service/src/amplifier_distro/server/__init__.py
+++ b/distro-service/src/amplifier_distro/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server management utilities for amplifier-distro."""

--- a/distro-service/src/amplifier_distro/server/daemon.py
+++ b/distro-service/src/amplifier_distro/server/daemon.py
@@ -1,0 +1,26 @@
+"""PID-file utilities for the amplifier-distro server."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def read_pid(pid_path: Path) -> int | None:
+    """Read an integer PID from a .pid file. Returns None on any error."""
+    try:
+        return int(pid_path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def is_running(pid_path: Path) -> bool:
+    """Return True if the PID in the file corresponds to a live process."""
+    pid = read_pid(pid_path)
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)  # signal 0 = existence check, no signal sent
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False


### PR DESCRIPTION
## Summary

Fixes multiple CI pipeline failures introduced in #210.

### Changes

- **distro_plugin/routes.py**: Remove unused `dataclass` import (F401 lint error)
- **ci.yml**: Change `uvx pyright` to `uv run --with pyright pyright` so pyright runs inside the project venv and can resolve dependencies
- **deps-update.yml**: Add explicit `permissions: contents: write, pull-requests: write` so GITHUB_TOKEN can push branches and open PRs
- **doctor.py**: Fix `from . import tailscale` to `from amplifierd.security import tailscale` (module lives in amplifierd, not locally)
- **amplifier_distro/distro_settings.py**: Add missing shim (zero-arg wrapper around plugin's `load(DistroPluginSettings())`)
- **server/daemon.py**: Add missing PID-file utilities (`read_pid()` and `is_running()`) referenced by doctor.py
- **distro_plugin/distro_settings.py**: Add `TlsSettings`, `ServerSettings` dataclasses and `server` field to `DistroSettings` schema so `settings.server.tls.*` resolves

---
🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)