### PR TITLE
chore: bump amplifier-chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", branch = "main" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "bd5787a98aa49a499164f4ef97bc38c66c8522d5" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }


### PR DESCRIPTION
## Summary
- Pins `amplifier-chat` to `bd5787a` to pick up the fix from [microsoft/amplifier-chat#34](https://github.com/microsoft/amplifier-chat/pull/34) (pin-priority fix)
- Replaces floating `branch = "main"` with an explicit `rev` pin

## Test plan
- [ ] CI passes

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)