### PR TITLE
chore: bump amplifier-chat to 60b7714

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "bd5787a98aa49a499164f4ef97bc38c66c8522d5" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "60b77148f10c0988d66fee1e6501b0edd835b970" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }


### PR DESCRIPTION
## Summary
- Bumps `amplifier-chat` rev from `bd5787a` to `60b7714`
- Picks up: fix: clear orphaned streaming cursors on cancel, error, and block transitions (#31)

## Test plan
- [ ] Verify streaming cursor cleanup on cancel, error, and block transitions

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)