### PR TITLE
chore: bump amplifier-chat and amplifierd

### DIFF
--- a/.amplifier/recipes/github-issue-triage.yaml
+++ b/.amplifier/recipes/github-issue-triage.yaml
@@ -388,8 +388,7 @@ stages:
           skipped_findings=$(jq -nc \
             --argjson has "$has_finding" \
             --argjson sel "$selected" \
-            '[$has[] | select(.issue_number as $n |\
-              [$sel[].issue_number] | index($n) | not)]')
+            '[$has[] | select(.issue_number as $n | [$sel[].issue_number] | index($n) | not)]')
 
           # Split selected issues into batches
           batch_size={{batch_size}}

--- a/distro-service/uv.lock
+++ b/distro-service/uv.lock
@@ -30,7 +30,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?rev=main#19415d6dbcf9581ee17228f05ebaae35d99b45ac" }
+source = { git = "https://github.com/microsoft/amplifier-chat?rev=main#60b77148f10c0988d66fee1e6501b0edd835b970" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "amplifierd"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifierd?branch=main#a3ab14d102aa0e4907b79c312bda98dd06c0ecc4" }
+source = { git = "https://github.com/microsoft/amplifierd?branch=main#1bd9b24d31360d4b0145aa00750c48ea08da13c8" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#4aa6763428063cb850a197fdd7692d197512170c" }
+source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#60b77148f10c0988d66fee1e6501b0edd835b970" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bumps **amplifier-chat** from `4aa6763` → `60b7714` in both `uv.lock` and `distro-service/uv.lock`
- Bumps **amplifierd** from `a3ab14d` → `1bd9b24` in `distro-service/uv.lock`
- Cosmetic whitespace fix in `.amplifier/recipes/github-issue-triage.yaml` (multi-line jq expression collapsed to single line)

**Picked up fixes:**
- amplifier-chat `60b77148`: fix: clear orphaned streaming cursors on cancel, error, and block transitions
- amplifierd `1bd9b24d`: fix: update references from amplifier_lib to amplifier_foundation across the codebase

Both lockfiles required updating: the root `uv.lock` was updated via `uv lock --upgrade-package`; `distro-service/uv.lock` was edited directly since it is a workspace member where `uv lock` resolves the workspace root.

## Test plan

- [ ] CI passes

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)