### PR TITLE
fix: settings save payload format and post-save state handling

### DIFF
--- a/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/settings.html
+++ b/amplifierd-plugins/amplifierd-plugin-distro/src/distro_plugin/static/settings.html
@@ -987,11 +987,11 @@ async function saveConfig(field) {
   let body = {};
 
   if (field === 'workspace_root') {
-    body = { workspace_root: value };
+    body = { values: { workspace_root: value } };
   } else if (field === 'github_handle') {
-    body = { identity: { github_handle: value } };
+    body = { section: 'identity', values: { github_handle: value } };
   } else if (field === 'git_email') {
-    body = { identity: { git_email: value } };
+    body = { section: 'identity', values: { git_email: value } };
   }
 
   const btn = document.getElementById('btn-save-' + field);
@@ -1000,7 +1000,15 @@ async function saveConfig(field) {
   const res = await api('POST', '/distro-settings', body);
 
   if (res && !res.error) {
-    state.config = (res.settings) ? res.settings : res;
+    if (field === 'workspace_root') {
+      state.config.workspace_root = value;
+    } else if (field === 'github_handle') {
+      if (!state.config.identity) state.config.identity = {};
+      state.config.identity.github_handle = value;
+    } else if (field === 'git_email') {
+      if (!state.config.identity) state.config.identity = {};
+      state.config.identity.git_email = value;
+    }
     showToast('Saved', 'success');
   } else {
     showToast('Failed to save', 'error');


### PR DESCRIPTION
## Summary

Fixes #215 — Settings changes made in the UI were silently lost on save.

## Root Cause

Two bugs in `saveConfig()` in `settings.html`:

### Bug 1: Payload format mismatch (primary)

The frontend sent flat objects like `{ workspace_root: value }`, but the backend `DistroSettingsUpdate` Pydantic model expects `{ values: { workspace_root: value } }` (and `{ section: ..., values: { ... } }` for sectioned settings like git). Pydantic silently ignored the unknown top-level keys, so `update_distro_settings()` was called with empty kwargs — a no-op.

### Bug 2: Post-save state clobbering (secondary)

After POST, the backend returns `{"status": "ok"}`. The frontend did:
```js
state.config = res.settings ? res.settings : res
```
Since `res.settings` is undefined, this fell through to `state.config = {"status": "ok"}`, wiping all in-memory config values until next page reload.

## Fix

- Wrapped save payloads in the `{ values: { ... } }` / `{ section: ..., values: { ... } }` structure the backend expects.
- Replaced the blanket `state.config` overwrite with targeted field updates that preserve the rest of the in-memory config.