### PR TITLE
chore: bump amplifier-chat to 13d386f, amplifierd to 7bbabb2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "60b77148f10c0988d66fee1e6501b0edd835b970" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "13d386f0370f7df3f535a762e9c6cc645075bf78" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#60b77148f10c0988d66fee1e6501b0edd835b970" }
+source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#13d386f0370f7df3f535a762e9c6cc645075bf78" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "amplifierd"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifierd?branch=main#1bd9b24d31360d4b0145aa00750c48ea08da13c8" }
+source = { git = "https://github.com/microsoft/amplifierd?branch=main#7bbabb2103ea03b8ba59f4388ea6f334d05b243c" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },


### PR DESCRIPTION
- **amplifier-chat** (4 commits since 60b7714):
  - 13d386f feat: global SSE — single connection for all sessions (#40)
  - 783a924 fix: remove orphaned scan_sessions call using removed ensure_ids param (#37)
  - 4be78ae fix: SSE reliability — unconditional prompt_complete release + reconnect reconciliation (#36)
  - 842adbb fix: pin/unpin sub-session leaks and resume race condition
- **amplifierd** (1 commit since 1bd9b24):
  - 7bbabb2 feat: SSE reliability — logging, keepalive, sequence IDs, error isolation (#23)
- Updated pyproject.toml rev pin for amplifier-chat
- Updated root uv.lock via `uv lock --upgrade-package`

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>