### PR TITLE
chore: bump amplifier-chat to 604ce04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "d4ecd2a2cdb2d465e1f836a15a20c6f56861792e" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "604ce0448585e191e28cfb23db7f321a80b2b854" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#13d386f0370f7df3f535a762e9c6cc645075bf78" }
+source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#604ce0448585e191e28cfb23db7f321a80b2b854" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump amplifier-chat to latest main (604ce0448585e191e28cfb23db7f321a80b2b854)

## Test plan
- [ ] Lock file resolves cleanly (confirmed via `uv lock`)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)