### PR TITLE
fix: add voice extra to amplifier-chat dependency

### DIFF
--- a/distro-service/pyproject.toml
+++ b/distro-service/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "amplifierd",
     "amplifierd-plugin-distro",
-    "amplifier-chat",
+    "amplifier-chat[voice]",
     "amplifierd-plugin-slack",
     "amplifierd-plugin-voice",
     "amplifierd-plugin-auth",


### PR DESCRIPTION
Install `amplifier-chat[voice]` so voice optional dependencies (`pywhispercpp`, `av`, `edge-tts`) are included out of the box in the distro service.

### Change
```diff
-    "amplifier-chat",
+    "amplifier-chat[voice]",
```

### Why
`amplifier-chat` defines a `voice` optional extra. Without specifying it, the voice dependencies aren't installed and the voice feature fails at runtime.