### PR TITLE
chore: bump amplifier-chat to 587cd86

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "982a52bd9de6a545af4ab6627a877d010dc5dffa" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "587cd86eec2ef4b6ccbc2dfac614d3ee843c33ba" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#982a52bd9de6a545af4ab6627a877d010dc5dffa" }
+source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#587cd86eec2ef4b6ccbc2dfac614d3ee843c33ba" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },


### PR DESCRIPTION
Updates amplifier-chat from 982a52b to 587cd86:

- fix: finalize synthetic animations on early cancellation to prevent truncated content (microsoft/amplifier-chat#47)

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>