### PR TITLE
chore: bump amplifierd and amplifier-chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ members = [
 # so they resolve for any member that declares them.
 [tool.uv.sources]
 amplifierd = { git = "https://github.com/microsoft/amplifierd", branch = "main" }
-amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "587cd86eec2ef4b6ccbc2dfac614d3ee843c33ba" }
+amplifier-chat = { git = "https://github.com/microsoft/amplifier-chat", rev = "7c7d8452fbd9b2823c9764c3399a640f426ad509" }
 amplifierd-plugin-voice = { git = "https://github.com/microsoft/amplifier-voice", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ requires-dist = [
 [[package]]
 name = "amplifier-chat"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#587cd86eec2ef4b6ccbc2dfac614d3ee843c33ba" }
+source = { git = "https://github.com/microsoft/amplifier-chat?branch=main#7c7d8452fbd9b2823c9764c3399a640f426ad509" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "amplifierd"
 version = "0.1.0"
-source = { git = "https://github.com/microsoft/amplifierd?branch=main#7bbabb2103ea03b8ba59f4388ea6f334d05b243c" }
+source = { git = "https://github.com/microsoft/amplifierd?branch=main#2c7ce158d2d3547db2eb907eb11591db67f9c01e" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },


### PR DESCRIPTION
Bump both dependencies to latest main:

- **amplifierd**: `7bbabb21` → `2c7ce158`
- **amplifier-chat**: `982a52bd` → `7c7d8452`

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)